### PR TITLE
Separate Main page template

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,13 @@
 ---
+import { getEntry } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+
+// this is the slug for en/index.mdx in the content collection
+const homePage = await getEntry("text-detail", "en");
+const { title } = homePage.data;
+const { Content } = await homePage.render();
 ---
 
-<BaseLayout title="Index" subHeading="The main page" />
+<BaseLayout title={title}>
+  <Content />
+</BaseLayout>


### PR DESCRIPTION
~~Should be reviewed merged after #21~~

This approach lets us use a different template for the homepage than from other pages in the text-detail collection. This doesn't address the localization aspect of this, but that will be addressed in #19.