### PR TITLE
Path aliases

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   removeDefaultLocalePrefix,
-} from "./_utils";
+} from "@pages/_utils";
 
 export const getStaticPaths = async () => {
   const pages = await getCollectionInDefaultLocale("text-detail");

--- a/src/pages/[locale]/[...slug].astro
+++ b/src/pages/[locale]/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInNonDefaultLocales,
   removeLocalePrefixfromSlug,
-} from "../_utils";
+} from "@pages/_utils";
 
 export const getStaticPaths = async () => {
   const pages = await getCollectionInNonDefaultLocales("text-detail");

--- a/src/pages/[locale]/contributor-docs/[...slug].astro
+++ b/src/pages/[locale]/contributor-docs/[...slug].astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   convertContributorDocIndexSlugIfNeeded,
   getCollectionInNonDefaultLocales,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const pastEvents = await getCollectionInNonDefaultLocales("contributor-docs");

--- a/src/pages/[locale]/examples/[...slug].astro
+++ b/src/pages/[locale]/examples/[...slug].astro
@@ -1,11 +1,11 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   exampleContentSlugToLegacyWebsiteSlug,
   getCollectionInNonDefaultLocales,
   getExampleCode,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const examples = await getCollectionInNonDefaultLocales("examples");

--- a/src/pages/[locale]/examples/index.astro
+++ b/src/pages/[locale]/examples/index.astro
@@ -1,8 +1,11 @@
 ---
-import { getCollectionInLocale, transformExampleSlugs } from "../../_utils";
-import ExamplesLayout from "../../../layouts/ExamplesLayout.astro";
-import { nonDefaultSupportedLocales } from "../../../../const";
-import { getCollectionInDefaultLocale } from "../../_utils";
+import {
+  getCollectionInLocale,
+  transformExampleSlugs,
+  getCollectionInDefaultLocale,
+} from "@pages/_utils";
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import { nonDefaultSupportedLocales } from "@/const";
 
 export async function getStaticPaths() {
   const pages = nonDefaultSupportedLocales.map(async (locale) => ({

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { nonDefaultSupportedLocales } from "../../../const";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import { nonDefaultSupportedLocales } from "@/const";
 
 export const getStaticPaths = async () => {
   const pages = await Promise.all(

--- a/src/pages/[locale]/libraries.astro
+++ b/src/pages/[locale]/libraries.astro
@@ -1,7 +1,7 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { nonDefaultSupportedLocales } from "../../../const";
-import { getCollectionInLocale } from "../_utils";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import { nonDefaultSupportedLocales } from "@/const";
+import { getCollectionInLocale } from "@pages/_utils";
 
 export const getStaticPaths = async () => {
   return await Promise.all(

--- a/src/pages/[locale]/past-events/[...slug].astro
+++ b/src/pages/[locale]/past-events/[...slug].astro
@@ -2,7 +2,7 @@
 import {
   getCollectionInNonDefaultLocales,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const pastEvents = await getCollectionInNonDefaultLocales("past-events");

--- a/src/pages/[locale]/people.astro
+++ b/src/pages/[locale]/people.astro
@@ -1,7 +1,7 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { nonDefaultSupportedLocales } from "../../../const";
-import { getCollectionInLocale } from "../_utils";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import { nonDefaultSupportedLocales } from "@/const";
+import { getCollectionInLocale } from "@pages/_utils";
 
 export const getStaticPaths = async () => {
   return await Promise.all(

--- a/src/pages/[locale]/reference/[...id].astro
+++ b/src/pages/[locale]/reference/[...id].astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInNonDefaultLocales,
   makeReferencePageSlug,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const referenceEntries = await getCollectionInNonDefaultLocales("reference");

--- a/src/pages/[locale]/reference/index.astro
+++ b/src/pages/[locale]/reference/index.astro
@@ -1,11 +1,11 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
-import { nonDefaultSupportedLocales } from "../../../../const";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import { nonDefaultSupportedLocales } from "@/const";
 import {
   getCollectionInLocale,
   makeReferencePageSlug,
   removeDefaultLocalePrefix,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const paths = nonDefaultSupportedLocales.map(async (locale) => ({

--- a/src/pages/[locale]/sketches/[...slug].astro
+++ b/src/pages/[locale]/sketches/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInNonDefaultLocales,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const pastEvents = await getCollectionInNonDefaultLocales("sketches");

--- a/src/pages/[locale]/tutorials/[...slug].astro
+++ b/src/pages/[locale]/tutorials/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInNonDefaultLocales,
   removeLocalePrefixfromSlug,
-} from "../../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const tutorials = await getCollectionInNonDefaultLocales("tutorials");

--- a/src/pages/contributor-docs/[...slug].astro
+++ b/src/pages/contributor-docs/[...slug].astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   convertContributorDocIndexSlugIfNeeded,
   getCollectionInDefaultLocale,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const contributorDocs =

--- a/src/pages/examples/[...slug].astro
+++ b/src/pages/examples/[...slug].astro
@@ -2,9 +2,10 @@
 import {
   exampleContentSlugToLegacyWebsiteSlug,
   removeDefaultLocalePrefix,
-} from "../_utils";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { getCollectionInDefaultLocale, getExampleCode } from "../_utils";
+  getCollectionInDefaultLocale,
+  getExampleCode,
+} from "@pages/_utils";
+import BaseLayout from "@layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const examples = await getCollectionInDefaultLocale("examples");

--- a/src/pages/examples/index.astro
+++ b/src/pages/examples/index.astro
@@ -1,6 +1,9 @@
 ---
-import { getCollectionInDefaultLocale, transformExampleSlugs } from "../_utils";
-import ExamplesLayout from "../../layouts/ExamplesLayout.astro";
+import {
+  getCollectionInDefaultLocale,
+  transformExampleSlugs,
+} from "@pages/_utils";
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
 
 // Using the transformed collection
 const exampleEntries = transformExampleSlugs<"examples">(

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import { getEntry } from "astro:content";
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 
 // this is the slug for en/index.mdx in the content collection
 const homePage = await getEntry("text-detail", "en");

--- a/src/pages/libraries.astro
+++ b/src/pages/libraries.astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 
 const libraries = await getCollection("libraries");
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title="Libraries" subHeading="">

--- a/src/pages/past-events/[...slug].astro
+++ b/src/pages/past-events/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   // get all past events pages that are in the default locale

--- a/src/pages/people.astro
+++ b/src/pages/people.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 const people = await getCollection("people");
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title="People">

--- a/src/pages/reference/[...id].astro
+++ b/src/pages/reference/[...id].astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   makeReferencePageSlug,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const referenceEntries = await getCollectionInDefaultLocale("reference");

--- a/src/pages/reference/index.astro
+++ b/src/pages/reference/index.astro
@@ -1,10 +1,10 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   makeReferencePageSlug,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 const referenceEntries = await getCollectionInDefaultLocale("reference");
 ---
 

--- a/src/pages/sketches/[...slug].astro
+++ b/src/pages/sketches/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const sketches = await getCollectionInDefaultLocale("sketches");

--- a/src/pages/tutorials/[...slug].astro
+++ b/src/pages/tutorials/[...slug].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 import {
   getCollectionInDefaultLocale,
   removeDefaultLocalePrefix,
-} from "../_utils";
+} from "@pages/_utils";
 
 export async function getStaticPaths() {
   const tutorials = await getCollectionInDefaultLocale("tutorials");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,18 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
-    "allowJs": true
+    "allowJs": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@src/*": ["src/*"],
+      "@components/*": ["src/components/*"],
+      "@content/*": ["src/content/*"],
+      "@scripts/*": ["src/scripts/*"],
+      "@layouts/*": ["src/layouts/*"],
+      "@pages/*": ["src/pages/*"],
+      "@tests/*": ["src/tests/*"],
+      "@types/*": ["src/types/*"],
+    },
   }
 }


### PR DESCRIPTION
I wanted this quality of life improvement so I decided to do it now before it became trickier. I think aliases are especially important because IDE's can't auto-detect the import location of Astro components. Also we are moving files around a lot so it would be nice to not worry about broken imports.