### PR TITLE
Add About page

### DIFF
--- a/src/content/text-detail/en/about.mdx
+++ b/src/content/text-detail/en/about.mdx
@@ -1,6 +1,5 @@
 ---
-
-title: "Access"
+title: "About"
 ---
 
 # Our Focus on Access

--- a/src/content/text-detail/en/about.mdx
+++ b/src/content/text-detail/en/about.mdx
@@ -2,43 +2,26 @@
 title: "About"
 ---
 
-# Our Focus on Access
+## Community Statement
 
-At the [2019 Contributors Conference](https://p5js.org/community/contributors-conference-2019.html), we made a commitment to only add features to p5.js that increase access (meaning inclusion and/or accessibility). This means considering the vectors of diversity (e.g. gender, social, economic, race, ethnicity, language, disability, etc.) that can impact access/participation; and taking action to acknowledge, dismantle, and prevent barriers. We prioritize the needs of historically marginalized groups over the continued comfort of more privileged groups with p5.js.
+p5.js is a community interested in exploring the creation of art and design with technology.
 
-We will not accept feature requests that don't support our effort to increase access. You'll see this criteria reflected in our issue and pull request templates.
+We are a community of, and in solidarity with, people from every gender identity and expression, sexual orientation, race, ethnicity, language, neuro-type, size, ability, class, religion, culture, subculture, political opinion, age, skill level, occupation, and background. We acknowledge that not everyone has the time, financial means, or ... 
 
-This is part of an ongoing conversation about access and inclusion within p5.js. Our intention to hold these as core values from which p5.js is built is laid out in our [Community Statement](../CODE_OF_CONDUCT.md), which was written at the [2015 Contributors Conference](https://p5js.org/community/contributors-conference-2015.html).
+Read more
 
-**Please consider this a starting point.** We want to invite more conversations about what access means and how we can prioritize it.
+## Code of Conduct
 
-## Kinds of access
+Be mindful of your language. Any of the following behavior is unacceptable
 
-Increasing access is not a focus on expanding the raw number of people in the p5.js community. It is a focus on making p5.js available to and approachable for people who are excluded from the p5.js community (intentionally or not) and from similar tools and communities.
+- Offensive comments related to gender identity and expression, sexual orientation, race, ethnicity, language, neuro-type, size, ability, class, religion, culture, subculture, political opinion, age, skill level, occupation, or background
+- Threats of violence
+- Deliberate intimidation ... 
 
-Access here means making p5.js better for:
+Read more
 
-- People who speak languages other than English
-- Black people, Indigenous peoples, and People of Color
-- People who are lesbian, gay, bisexual, trans, or queer
-- People with marginalized genders
-- People with disabilities or illness
-- People who lack opportunities and/or resources to engage with creative coding due to class or income
-- People with little or no prior experience in open source and creative coding
-- and other people who are systemically excluded and historically underrepresented
+## Access Statement
 
-### Examples
+At the 2019 Contributors Conference, we made a commitment to only add features to p5.js that increase access (meaning inclusion and/or accessibility). This means considering the vectors of diversity (e.g. gender, social, economic, race, ethnicity, language, disability, etc.) that can impact access/participation; and taking action to acknowledge, dismantle, and prevent barriers. We prioritize the needs of historically marginalized groups over the continued comfort of ... 
 
-These are examples of efforts we believe to increase access:
-
-- Translating more documentation and other materials into more languages
-- Improving our support for assistive technologies (such as screenreaders)
-- Following Web Content Accessibility Guidelines in our tools and working towards making it easier for users to follow them in their projects
-- Making p5.js error messages more helpful and supportive to people using the tool
-- Mentoring and supporting learners of p5.js within communities that are historically excluded from and marginalized in creative coding and the digital arts
-
-There are other things we haven't thought of yet and we're excited to figure out what they are together. If you have an idea, please [share it as an issue](https://github.com/processing/p5.js/issues/new/choose).
-
-## Maintenance
-
-We also affirm our intention to maintain the existing feature set of p5.js. We'd like to fix bugs regardless of which area of the codebase they're in because we believe consistency of the tool makes it more accessible for beginners.
+[Read more](/access)

--- a/src/content/text-detail/en/access.mdx
+++ b/src/content/text-detail/en/access.mdx
@@ -1,5 +1,4 @@
 ---
-
 title: "Access"
 ---
 

--- a/src/content/text-detail/en/code-of-conduct.mdx
+++ b/src/content/text-detail/en/code-of-conduct.mdx
@@ -1,5 +1,4 @@
 ---
-slug: "code-of-conduct"
 title: "Code of Conduct"
 ---
 

--- a/src/content/text-detail/en/contact.mdx
+++ b/src/content/text-detail/en/contact.mdx
@@ -1,5 +1,4 @@
 ---
-slug: "contact"
 title: "Contact"
 ---
 

--- a/src/content/text-detail/en/donate.mdx
+++ b/src/content/text-detail/en/donate.mdx
@@ -1,5 +1,4 @@
 ---
-slug: "donate"
 title: "Donate"
 ---
 

--- a/src/pages/[locale]/[slug].astro
+++ b/src/pages/[locale]/[slug].astro
@@ -19,6 +19,17 @@ export const getStaticPaths = async () => {
         // don't generate "index" pages, those are handled by ./index.astro
         if (slug === "/") return null;
 
+        // if slug has / at the beginning (and will if we only remove
+        // the locale prefix) then chop it off
+        // this is necessary because this file is [slug].astro and
+        // not [...slug].astro, so sub routes are not allowed
+        if (slug.startsWith("/")) {
+          return {
+            params: { locale, slug: slug.slice(1) },
+            props: { page },
+          };
+        }
+
         return { params: { locale, slug }, props: { page } };
       });
     })

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -13,6 +13,17 @@ export const getStaticPaths = async () => {
       // don't generate "index" pages, those are handled by ./index.astro
       if (slug === "/") return null;
 
+      // if slug has / at the beginning (and will if we only remove
+      // the locale prefix) then chop it off
+      // this is necessary because this file is [slug].astro and
+      // not [...slug].astro, so sub routes are not allowed
+      if (slug.startsWith("/")) {
+        return {
+          params: { slug: slug.slice(1) },
+          props: { page },
+        };
+      }
+
       return { params: { slug }, props: { page } };
     })
     .filter((p) => p !== null);


### PR DESCRIPTION
- also removes manual slugs in the en/ folder of the text-detail collection
- and fixes text-detail routing to account for that