### PR TITLE
Fall back to English example code if not present in other locales

### DIFF
--- a/src/content/examples/es/00_Structure/03_Setup_and_Draw/description.mdx
+++ b/src/content/examples/es/00_Structure/03_Setup_and_Draw/description.mdx
@@ -1,0 +1,6 @@
+---
+title: Setup y Draw
+arialabel: Una linea horizontal de color blanco animada sobre un fondo negro que se mueve de abajo hacía arriba en la pantalla
+---
+
+El código dentro de la función draw() se ejecuta continuamente de arriba hacia abajo hasta que el programa se detiene. El código en setup() se ejecuta una sola vez cuando el programa empieza

--- a/src/content/examples/es/00_Structure/03_Setup_and_Draw/description.mdx
+++ b/src/content/examples/es/00_Structure/03_Setup_and_Draw/description.mdx
@@ -1,6 +1,0 @@
----
-title: Setup y Draw
-arialabel: Una linea horizontal de color blanco animada sobre un fondo negro que se mueve de abajo hacía arriba en la pantalla
----
-
-El código dentro de la función draw() se ejecuta continuamente de arriba hacia abajo hasta que el programa se detiene. El código en setup() se ejecuta una sola vez cuando el programa empieza

--- a/src/pages/_utils-node.ts
+++ b/src/pages/_utils-node.ts
@@ -1,8 +1,19 @@
-import { readFile } from "fs/promises";
+import { readFile, access } from "fs/promises";
+import { constants } from "fs";
+import { removeLocalePrefix } from "@i18n/utils";
 
 // THIS FILE OF UTILS IS FOR CODE THAT NEEDS NODEJS RUNTIME DEPS
 // IT CANNOT BE IMPORTED INTO A COMPONENT THAT RENDERS ON THE CLIENT
 // TODO: PICK A BETTER NAME FOR THIS FILE
+
+/**
+ * @returns whether or not a file exists at a given path.
+ */
+export async function checkFileExists(file: string): Promise<boolean> {
+  return access(file, constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
 
 /**
  * Returns the code sample needed for the example given.
@@ -11,7 +22,17 @@ import { readFile } from "fs/promises";
  * @returns
  */
 export const getExampleCode = async (exampleId: string): Promise<string> => {
-  const codePath = `src/content/examples/${exampleId.replace("description.mdx", "code.js")}`;
+  let codePath = `src/content/examples/${exampleId.replace(
+    "description.mdx",
+    "code.js",
+  )}`;
+  if (!(await checkFileExists(codePath))) {
+    // Fall back to the English version
+    codePath = `src/content/examples/en/${removeLocalePrefix(exampleId).replace(
+      "description.mdx",
+      "code.js",
+    )}`;
+  }
   const code = await readFile(codePath, "utf-8");
   return code;
 };


### PR DESCRIPTION
Resolves https://github.com/bocoup/p5.js-website/issues/58

This falls back to the `/en` version of an example's code if one isn't present in another locale, so that automatic PRs from GitLocalize that only include a translated mdx will still build.