### PR TITLE
UI translation files

### DIFF
--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -18,8 +18,8 @@ const t = await useTranslations(currentLocale);
     <li><a href="/download">{t("Download")}</a></li>
     <li><a href="/contact">{t("Contact")}</a></li>
     <li><a href="/copyright">{t("Copyright")}</a></li>
-    <li><a href="/privacy-policy">{t("PrivacyPolicy")}</a></li>
-    <li><a href="/terms-of-use">{t("TermsOfUse")}</a></li>
+    <li><a href="/privacy-policy">{t("Privacy Policy")}</a></li>
+    <li><a href="/terms-of-use">{t("Terms of Use")}</a></li>
     <li><a href="https://discourse.processing.org/c/p5js">{t("Forum")}</a></li>
   </ul>
 </div>

--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -1,0 +1,25 @@
+---
+import { getCurrentLocale, useTranslations } from "@/src/i18n/utils";
+
+const currentLocale = getCurrentLocale(Astro.url.pathname);
+const t = await useTranslations(currentLocale);
+---
+
+<div class="border-t border-black text-blue-600 underline">
+  <ul>
+    <li><a href="/">{t("Home")}</a></li>
+    <li><a href="/reference">{t("Reference")}</a></li>
+    <li><a href="/tutorials">{t("Tutorials")}</a></li>
+    <li><a href="/examples">{t("Examples")}</a></li>
+    <li><a href="/contribute">{t("Contribute")}</a></li>
+    <li><a href="/community">{t("Community")}</a></li>
+    <li><a href="/about">{t("About")}</a></li>
+    <li><a href="/donate">{t("Donate")}</a></li>
+    <li><a href="/download">{t("Download")}</a></li>
+    <li><a href="/contact">{t("Contact")}</a></li>
+    <li><a href="/copyright">{t("Copyright")}</a></li>
+    <li><a href="/privacy-policy">{t("PrivacyPolicy")}</a></li>
+    <li><a href="/terms-of-use">{t("TermsOfUse")}</a></li>
+    <li><a href="https://discourse.processing.org/c/p5js">{t("Forum")}</a></li>
+  </ul>
+</div>

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -1,3 +1,0 @@
-export const Footer = () => {
-  return <div>p5.js site footer goes here</div>;
-};

--- a/src/components/SearchForm/index.astro
+++ b/src/components/SearchForm/index.astro
@@ -1,7 +1,8 @@
 ---
-import { getCurrentLocale } from "@/src/i18n/utils";
+import { getCurrentLocale, useTranslations } from "@/src/i18n/utils";
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
+const t = await useTranslations(currentLocale);
 ---
 
 <form
@@ -9,7 +10,7 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
   method="GET"
   role="search"
 >
-  <label for="search-term">Search</label>
+  <label for="search-term">{t("Search")}</label>
   <input
     id="search-term"
     type="search"
@@ -18,5 +19,5 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
     aria-label="Search through site content"
     required
   />
-  <button type="submit">Search</button>
+  <button type="submit">{t("Search")}</button>
 </form>

--- a/src/content/text-detail/en/copyright.mdx
+++ b/src/content/text-detail/en/copyright.mdx
@@ -1,0 +1,5 @@
+---
+title: "Copyright"
+---
+
+## Copyright

--- a/src/content/text-detail/en/download.mdx
+++ b/src/content/text-detail/en/download.mdx
@@ -1,0 +1,5 @@
+---
+title: "Download"
+---
+
+## Download

--- a/src/content/text-detail/en/privacy-policy.mdx
+++ b/src/content/text-detail/en/privacy-policy.mdx
@@ -1,0 +1,5 @@
+---
+title: "Privacy Policy"
+---
+
+## Privacy Policy

--- a/src/content/text-detail/en/terms-of-use.mdx
+++ b/src/content/text-detail/en/terms-of-use.mdx
@@ -1,0 +1,5 @@
+---
+title: "Terms of Use"
+---
+
+## Terms of Use

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -9,28 +9,28 @@ Donate: Donate
 Download: Download
 Contact: Contact
 Copyright: Copyright
-PrivacyPolicy: Privacy Policy
-TermsOfUse: Terms of Use
-StartCoding: Start Coding
+Privacy Policy: Privacy Policy
+Terms of Use: Terms of Use
+Start Coding: Start Coding
 Forum: Forum
 Accessibility: Accessibility
 Search: Search
-JumpTo: Jump to
-SketchesArchive: Sketches Archive
+Jump To: Jump to
+Sketches Archive: Sketches Archive
 Sketches: Sketches
 Libraries: Libraries
-LibrariesArchive: Libraries Archive
-PastEvents: Past Events
-EventsArchive: Events Archive
+Libraries Archive: Libraries Archive
+Past Events: Past Events
+Events Archive: Events Archive
 People: People
-ViewAltText: View Alt Text
-MonochromeMode: Monochrome Mode
+View Alt Text: View Alt Text
+Monochrome Mode: Monochrome Mode
 Dark Mode: Dark Mode
-BriefPageDescriptions:
+briefPageDescriptions:
   Tutorials: A collection of lessons covering beginner, intermediate, and advanced topics
   Contribute: Ways to get involved with p5.js through code or donations.
   Community: p5.js is a community interested in exploring the creation of art and design with technology.
-  SketchesArchive: FINAL COPY NEEDED
-  EventArchive: FINAL COPY NEEDED
-  LibrariesArchive: FINAL COPY NEEDED
+  Sketches Archive: FINAL COPY NEEDED
+  Event Archive: FINAL COPY NEEDED
+  Libraries Archive: FINAL COPY NEEDED
   People: FINAL COPY NEEDED

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -1,0 +1,36 @@
+Home: Home
+Reference: Reference
+Tutorials: Tutorials
+Community: Community
+Examples: Examples
+Contribute: Contribute
+About: About
+Donate: Donate
+Download: Download
+Contact: Contact
+Copyright: Copyright
+PrivacyPolicy: Privacy Policy
+TermsOfUse: Terms of Use
+StartCoding: Start Coding
+Forum: Forum
+Accessibility: Accessibility
+Search: Search
+JumpTo: Jump to
+SketchesArchive: Sketches Archive
+Sketches: Sketches
+Libraries: Libraries
+LibrariesArchive: Libraries Archive
+PastEvents: Past Events
+EventsArchive: Events Archive
+People: People
+ViewAltText: View Alt Text
+MonochromeMode: Monochrome Mode
+Dark Mode: Dark Mode
+BriefPageDescriptions:
+  Tutorials: A collection of lessons covering beginner, intermediate, and advanced topics
+  Contribute: Ways to get involved with p5.js through code or donations.
+  Community: p5.js is a community interested in exploring the creation of art and design with technology.
+  SketchesArchive: FINAL COPY NEEDED
+  EventArchive: FINAL COPY NEEDED
+  LibrariesArchive: FINAL COPY NEEDED
+  People: FINAL COPY NEEDED

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -1,0 +1,36 @@
+Home: Inicio
+Reference: Referencia
+Tutorials: Tutoriales
+Community: Comunidad
+Examples: Ejemplos
+Contribute: Contribuir
+About: Acerca de
+Donate: Donar
+Download: Descargar
+Contact: Contacto
+Copyright: Derechos de autor
+PrivacyPolicy: Política de privacidad
+TermsOfUse: Términos de uso
+StartCoding: Comenzar a programar
+Forum: Foro
+Accessibility: Accesibilidad
+Search: Buscar
+JumpTo: Saltar a
+SketchesArchive: Archivo de Esbozos
+Sketches: Esbozos
+Libraries: Bibliotecas
+LibrariesArchive: Archivo de Bibliotecas
+PastEvents: Eventos Pasados
+EventsArchive: Archivo de Eventos
+People: Personas
+ViewAltText: Ver Texto Alternativo
+MonochromeMode: Modo Monocromo
+DarkMode: Modo Oscuro
+BriefPageDescriptions:
+  Tutorials: Una colección de lecciones que cubren temas para principiantes, intermedios y avanzados
+  Contribute: Formas de involucrarse con p5.js a través del código o donaciones.
+  Community: p5.js es una comunidad interesada en explorar la creación de arte y diseño con tecnología.
+  SketchesArchive: FINAL COPY NEEDED
+  EventArchive: FINAL COPY NEEDED
+  LibrariesArchive: FINAL COPY NEEDED
+  People: FINAL COPY NEEDED

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -9,28 +9,28 @@ Donate: Donar
 Download: Descargar
 Contact: Contacto
 Copyright: Derechos de autor
-PrivacyPolicy: Política de privacidad
-TermsOfUse: Términos de uso
-StartCoding: Comenzar a programar
+Privacy Policy: Política de privacidad
+Terms of Use: Términos de uso
+Start Coding: Comenzar a programar
 Forum: Foro
 Accessibility: Accesibilidad
 Search: Buscar
-JumpTo: Saltar a
-SketchesArchive: Archivo de Esbozos
+Jump To: Saltar a
+Sketches Archive: Archivo de Esbozos
 Sketches: Esbozos
 Libraries: Bibliotecas
-LibrariesArchive: Archivo de Bibliotecas
-PastEvents: Eventos Pasados
-EventsArchive: Archivo de Eventos
+Libraries Archive: Archivo de Bibliotecas
+Past Events: Eventos Pasados
+Events Archive: Archivo de Eventos
 People: Personas
-ViewAltText: Ver Texto Alternativo
-MonochromeMode: Modo Monocromo
-DarkMode: Modo Oscuro
-BriefPageDescriptions:
+View Alt Text: Ver Texto Alternativo
+Monochrome Mode: Modo Monocromo
+Dark Mode: Modo Oscuro
+briefPageDescriptions:
   Tutorials: Una colección de lecciones que cubren temas para principiantes, intermedios y avanzados
   Contribute: Formas de involucrarse con p5.js a través del código o donaciones.
   Community: p5.js es una comunidad interesada en explorar la creación de arte y diseño con tecnología.
-  SketchesArchive: FINAL COPY NEEDED
-  EventArchive: FINAL COPY NEEDED
-  LibrariesArchive: FINAL COPY NEEDED
+  Sketches Archive: FINAL COPY NEEDED
+  Event Archive: FINAL COPY NEEDED
+  Libraries Archive: FINAL COPY NEEDED
   People: FINAL COPY NEEDED

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -88,7 +88,10 @@ const loadYamlIntoObject = async (
   filePath: string,
 ): Promise<Record<string, string>> => {
   try {
-    let fileContents = await readFile(filePath);
+    // Read the file with optional silent mode, this prevents
+    // console.errors during build with missing yaml. Silent mode can be removed
+    // after better translation coverage is achieved.
+    let fileContents = await readFile(filePath, true);
     // Add fences so that graymatter can parse yaml into object.
     // This is an alternative to using
     // a dedicated yaml parser.

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -102,6 +102,15 @@ const loadYamlIntoObject = async (
   }
 };
 
+/**
+ * Loads the translation files for a given locale and returns a function
+ * that can be used to get the localized value of a key.
+ * If the key is not found in the current locale, it will fallback to the
+ * default locale.
+ * If the key is not found in the default locale, it will return the key itself.
+ * @param lang The locale/language code
+ * @returns (key: string) => string - A function that takes a key and returns the localized value
+ */
 export const useTranslations = async (
   lang: (typeof supportedLocales)[number],
 ) => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,10 +1,11 @@
 ---
 import LocaleSwitcher from "@components/LocaleSwitcher/index.astro";
-import { Footer } from "@components/Footer";
+import Footer from "@/src/components/Footer/index.astro";
 import SearchForm from "@components/SearchForm/index.astro";
-import { getCurrentLocale } from "@i18n/utils";
+import { getCurrentLocale, useTranslations } from "@i18n/utils";
 const { title, subHeading } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url.pathname);
+const t = await useTranslations(currentLocale);
 ---
 
 <html>
@@ -15,13 +16,13 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
   <body>
     <nav>
       <ul>
-        <a href="/">Home</a>
-        <a href="/reference">Reference</a>
-        <a href="/tutorials">Tutorials</a>
-        <a href="/examples">Examples</a>
-        <a href="/community">Community</a>
-        <a href="/about">About</a>
-        <a href="/contribute">Contribute</a>
+        <a href="/">{t("Home")}</a>
+        <a href="/reference">{t("Reference")}</a>
+        <a href="/tutorials">{t("Tutorials")}</a>
+        <a href="/examples">{t("Examples")}</a>
+        <a href="/community">{t("Community")}</a>
+        <a href="/about">{t("About")}</a>
+        <a href="/contribute">{t("Contribute")}</a>
       </ul>
     </nav>
     <div class="flex space-x-2">

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -112,12 +112,17 @@ export const writeFile = async (filePath: string, data: string) => {
  * @param filePath Path to the file
  * @returns string the content of the file
  */
-export const readFile = async (filePath: string) => {
+export const readFile = async (
+  filePath: string,
+  silent: boolean | undefined = false,
+) => {
   try {
     const fileContent = await fs.readFile(filePath, "utf8");
     return fileContent;
   } catch (err) {
-    console.error(`Error reading file: ${err}`);
+    if (!silent) {
+      console.error(`Error reading file: ${err}`);
+    }
   }
 };
 


### PR DESCRIPTION
This PR adds YAML files for translating UI Elements

Tagging for awareness: @davepagurek @Qianqianye @limzykenneth 

New UI localization files are in `src/content/ui/{locale}.yaml` with this PR.

Notes:
- This PR adds Spanish locale translations in addition to english. These were confirmed with a native Spanish speaker but p5 should retranslate as desired
- There are some keys that have placeholder values "FINAL COPY NEEDED". These were cases where the final copy wasn't present in the mockups.
- I opted for exact English translations for keys that lead directly to values, and camelCase for categories
- Landing page brief descriptions were included here since these values are different than the single item brief descriptions discussed previously