### PR TITLE
[p5.js - es] Translate reference Accessibility, Environment, Math

### DIFF
--- a/src/content/reference/es/p5/abs.mdx
+++ b/src/content/reference/es/p5/abs.mdx
@@ -1,7 +1,7 @@
 ---
 title: abs
 module: Matemáticas
-submodule: Cálculo
+submodule: Cálculos
 file: src/math/calculation.js
 description: |-
   <p><code>abs()</code> calcula el valor absoluto de un número. </p>

--- a/src/content/reference/es/p5/cursor.mdx
+++ b/src/content/reference/es/p5/cursor.mdx
@@ -1,0 +1,109 @@
+---
+title: cursor
+module: Ambiente
+submodule: Ambiente
+file: src/core/environment.js
+description: >
+  <p><code>cursor()</code> cambia la apariencia de el cursor y cuenta con tres parámetros.</p>
+  <p>El primer parámetro, <code>type</code>, define el tipo de cursor que se mostrará. Entre las opciones predefinidas se encuentran  <code>ARROW</code>, <code>CROSS</code>, <code>HAND</code>, <code>MOVE</code>, <code>TEXT</code>, y <code>WAIT</code>.</p>
+  <p><code>cursor()</code>también reconoce propiedades de cursor que son estándar de CSS. Estas pueden ser usadas si se pasan como cadena de caracteres: <code>'help'</code>, <code>'wait'</code>, <code>'crosshair'</code>,<code>'not-allowed'</code>, <code>'zoom-in'</code>, and <code>'grab'</code>. Si se proporciona la ruta a una imagen, por ejemplo: cursor('assets/target.png'); entonces esa imagen se usará como cursor. Las imágenes deben estar en formato .cur, .gif, .jpg, .jpeg o .png y deben tener como máximo 32 por 32 píxeles de tamaño. </p>
+  <p>El segundo parámetro, <code>x</code>, y el tercer parámetro, <code>y</code> son opcionales y pueden ser utilizados para especificar la posición inicial del cursor. Por defecto, ambos tienen un valor de 0, lo que hace que el cursor comience en la esquina superior izquierda si se utiliza una imagen como cursor. Si se desea cambiar esta posición inicial, el valor proporcionado para <code>x</code> y <code>y</code> debe ser menor que el ancho y alto de la imagen, respectivamente.</p>
+  <p> Opciones predefinidas: ya sea ARROW, CROSS, HAND, MOVE, TEXT, o WAIT.
+  Propiedades de cursor estándar de CSS: ’crosshair’, ‘not-allowed’, ‘grab’, etc.
+  Ruta a una imagen. </p>
+line: 209
+isConstructor: false
+itemtype: method
+example:
+  - |-
+
+    <div>
+    <code>
+    function setup() {
+      createCanvas(100, 100);
+
+      describe('A gray square. The cursor appears as crosshairs.');
+    }
+
+    function draw() {
+      background(200);
+
+      // Set the cursor to crosshairs: +
+      cursor(CROSS);
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      createCanvas(100, 100);
+
+      describe('A gray square divided into quadrants. The cursor image changes when the mouse moves to each quadrant.');
+    }
+
+    function draw() {
+      background(200);
+
+      // Divide the canvas into quadrants.
+      line(50, 0, 50, 100);
+      line(0, 50, 100, 50);
+
+      // Change cursor based on mouse position.
+      if (mouseX < 50 && mouseY < 50) {
+        cursor(CROSS);
+      } else if (mouseX > 50 && mouseY < 50) {
+        cursor('progress');
+      } else if (mouseX > 50 && mouseY > 50) {
+        cursor('https://avatars0.githubusercontent.com/u/1617169?s=16');
+      } else {
+        cursor('grab');
+      }
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      createCanvas(100, 100);
+
+      describe('An image of three purple curves follows the mouse. The image shifts when the mouse is pressed.');
+    }
+
+    function draw() {
+      background(200);
+
+      // Change the cursor's active spot
+      // when the mouse is pressed.
+      if (mouseIsPressed === true) {
+        cursor('https://avatars0.githubusercontent.com/u/1617169?s=16', 8, 8);
+      } else {
+        cursor('https://avatars0.githubusercontent.com/u/1617169?s=16');
+      }
+    }
+    </code>
+    </div>
+class: p5
+params:
+  - name: type
+    description: |
+      <p>Opciones predefinidas: ya sea ARROW, CROSS, HAND, MOVE, TEXT, o WAIT.
+        Propiedades de cursor estándar de CSS: ’crosshair’, ‘not-allowed’, ‘grab’, etc.
+        Ruta a una imagen. </p>
+    type: String|Constant
+  - name: x
+    description: |
+      <p>punto activo horizontal del cursor.</p>
+    type: Number
+    optional: true
+  - name: 'y'
+    description: |
+      <p>punto activo vertical del cursor.</p>
+    type: Number
+    optional: true
+chainable: false
+---
+
+
+# cursor

--- a/src/content/reference/es/p5/deltaTime.mdx
+++ b/src/content/reference/es/p5/deltaTime.mdx
@@ -1,0 +1,56 @@
+---
+title: deltaTime
+module: Ambiente
+submodule: Ambiente
+file: src/core/environment.js
+description: >
+  <p>La variable <code>deltaTime</code> rastrea el número de milisegundos que tomó dibujar el último fotograma.</p><p> <code>deltaTime</code> contiene entonces la cantidad de tiempo que tomó <a href="./draw">draw()</a> para ejecutarse durante el fotograma anterior.</p> 
+  <p>Esta variable es útil para crear animaciones sensibles al tiempo o cálculos físicos que deben mantenerse constantes independientemente de los cuadros por segundo.</p>
+line: 124
+isConstructor: false
+itemtype: property
+example:
+  - |-
+
+    <div>
+    <code>
+    let x = 0;
+    let speed = 0.05;
+
+    function setup()  {
+      createCanvas(100, 100);
+
+      // Set the frameRate to 30.
+      frameRate(30);
+
+      describe('A white circle moves from left to right on a gray background. It reappears on the left side when it reaches the right side.');
+    }
+
+    function draw() {
+      background(200);
+
+      // Use deltaTime to calculate
+      // a change in position.
+      let deltaX = speed * deltaTime;
+
+      // Update the x variable.
+      x += deltaX;
+
+      // Reset x to 0 if it's
+      // greater than 100.
+      if (x > 100)  {
+        x = 0;
+      }
+
+      // Use x to set the circle's
+      // position.
+      circle(x, 50, 20);
+    }
+    </code>
+    </div>
+class: p5
+type: Integer
+---
+
+
+# deltaTime

--- a/src/content/reference/es/p5/describe.mdx
+++ b/src/content/reference/es/p5/describe.mdx
@@ -1,0 +1,110 @@
+---
+title: describe
+module: Ambiente
+submodule: Ambiente
+file: src/accessibility/describe.js
+description: >
+  <p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   <p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción. </p> 
+  <p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+  <p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
+line: 18
+isConstructor: false
+itemtype: method
+example:
+  - |-
+
+    <div>
+    <code>
+    function setup() {
+      background('pink');
+
+      // Draw a heart.
+      fill('red');
+      noStroke();
+      circle(67, 67, 20);
+      circle(83, 67, 20);
+      triangle(91, 73, 75, 95, 59, 73);
+
+      // Add a general description of the canvas.
+      describe('A pink square with a red heart in the bottom-right corner.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      background('pink');
+
+      // Draw a heart.
+      fill('red');
+      noStroke();
+      circle(67, 67, 20);
+      circle(83, 67, 20);
+      triangle(91, 73, 75, 95, 59, 73);
+
+      // Add a general description of the canvas
+      // and display it for debugging.
+      describe('A pink square with a red heart in the bottom-right corner.', LABEL);
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function draw() {
+      background(200);
+
+      // The expression
+      // frameCount % 100
+      // causes x to increase from 0
+      // to 99, then restart from 0.
+      let x = frameCount % 100;
+
+      // Draw the circle.
+      fill(0, 255, 0);
+      circle(x, 50, 40);
+
+      // Add a general description of the canvas.
+      describe(`A green circle at (${x}, 50) moves from left to right on a gray square.`);
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function draw() {
+      background(200);
+
+      // The expression
+      // frameCount % 100
+      // causes x to increase from 0
+      // to 99, then restart from 0.
+      let x = frameCount % 100;
+
+      // Draw the circle.
+      fill(0, 255, 0);
+      circle(x, 50, 40);
+
+      // Add a general description of the canvas
+      // and display it for debugging.
+      describe(`A green circle at (${x}, 50) moves from left to right on a gray square.`, LABEL);
+    }
+    </code>
+    </div>
+class: p5
+params:
+  - name: text
+    description: |
+      <p>descripción del lienzo.</p>
+    type: String
+  - name: display
+    description: |
+      <p>ya sea LABEL o FALLBACK.</p>
+    type: Constant
+    optional: true
+chainable: false
+---
+
+
+# describe

--- a/src/content/reference/es/p5/describeElement.mdx
+++ b/src/content/reference/es/p5/describeElement.mdx
@@ -1,13 +1,11 @@
 ---
 title: describeElement
-module: Environment
-submodule: Environment
+module: Ambiente
+submodule: Ambiente
 file: src/accessibility/describe.js
 description: >
-<p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   
-<p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción.</p> 
-<p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa 
-como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+  <p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   <p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción. </p> 
+<p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
 <p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
 
 line: 162
@@ -77,7 +75,7 @@ params:
     type: String
   - name: text
     description: |
-      <p>descripción del elemento.</p>
+      <p>descripción del elemento..</p>
     type: String
   - name: display
     description: |

--- a/src/content/reference/es/p5/describeElement.mdx
+++ b/src/content/reference/es/p5/describeElement.mdx
@@ -4,10 +4,14 @@ module: Ambiente
 submodule: Ambiente
 file: src/accessibility/describe.js
 description: >
-  <p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   <p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción. </p> 
-  <p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+  <p><code>describeElement()</code> genera una descripción de los elementos presentes en el lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia.</p>
+  <p>Los elementos son formas o grupos de formas que juntas crean significado. Por ejemplo, unos círculos superpuestos podrían formar un  elemento “ojo”.</p>
+  <p><code>describeElement()</code> cuenta con tres parámetros.</p>   
+  <p>El primer parámetro, <code>name</code>, es el nombre del elemento.</p>
+  <p>El segundo parámetro, <code>text</code>, es la descripción del elemento.</p>
+  <p>
+  El tercer parámetro, <code>display</code>, es opcional y determina de qué manera se va a mostrar la descripción.  Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Sin embargo, el uso de <code>LABEL</code> crea mensajes duplicados que son ineficientes para los usuarios de lectores de pantalla, por lo que recomendamos utilizar únicamente <code>LABEL</code> durante la fase de desarrollo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
   <p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
-
 line: 162
 isConstructor: false
 itemtype: method

--- a/src/content/reference/es/p5/describeElement.mdx
+++ b/src/content/reference/es/p5/describeElement.mdx
@@ -1,0 +1,91 @@
+---
+title: describeElement
+module: Environment
+submodule: Environment
+file: src/accessibility/describe.js
+description: >
+<p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   
+<p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción.</p> 
+<p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa 
+como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+<p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
+
+line: 162
+isConstructor: false
+itemtype: method
+example:
+  - |-
+
+    <div>
+    <code>
+    function setup() {
+      background('pink');
+
+      // Describe the first element
+      // and draw it.
+      describeElement('Circle', 'A yellow circle in the top-left corner.');
+      noStroke();
+      fill('yellow');
+      circle(25, 25, 40);
+
+      // Describe the second element
+      // and draw it.
+      describeElement('Heart', 'A red heart in the bottom-right corner.');
+      fill('red');
+      circle(66.6, 66.6, 20);
+      circle(83.2, 66.6, 20);
+      triangle(91.2, 72.6, 75, 95, 58.6, 72.6);
+
+      // Add a general description of the canvas.
+      describe('A red heart and yellow circle over a pink background.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      background('pink');
+
+      // Describe the first element
+      // and draw it. Display the
+      // description for debugging.
+      describeElement('Circle', 'A yellow circle in the top-left corner.', LABEL);
+      noStroke();
+      fill('yellow');
+      circle(25, 25, 40);
+
+      // Describe the second element
+      // and draw it. Display the
+      // description for debugging.
+      describeElement('Heart', 'A red heart in the bottom-right corner.', LABEL);
+      fill('red');
+      circle(66.6, 66.6, 20);
+      circle(83.2, 66.6, 20);
+      triangle(91.2, 72.6, 75, 95, 58.6, 72.6);
+
+      // Add a general description of the canvas.
+      describe('A red heart and yellow circle over a pink background.');
+    }
+    </code>
+    </div>
+class: p5
+params:
+  - name: name
+    description: |
+      <p>nombre del elemento.</p>
+    type: String
+  - name: text
+    description: |
+      <p>descripción del elemento.</p>
+    type: String
+  - name: display
+    description: |
+      <p>ya sea LABEL o FALLBACK.</p>
+    type: Constant
+    optional: true
+chainable: false
+---
+
+
+# describeElement

--- a/src/content/reference/es/p5/describeElement.mdx
+++ b/src/content/reference/es/p5/describeElement.mdx
@@ -5,8 +5,8 @@ submodule: Ambiente
 file: src/accessibility/describe.js
 description: >
   <p><code>describe()</code> genera una descripción del lienzo, la cual es accesible para lectores de pantalla y otras tecnologías de asistencia. <code>describe()</code> cuenta con dos parámetros.</p>   <p>El primer parámetro, <code>text</code>, cumple la función de describir lo que se puede observar en el lienzo.</p> <p>El segundo parámetro, <code>display</code> es opcional y determina de qué manera se va a mostrar la descripción. </p> 
-<p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
-<p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
+  <p>Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>describe('Descripción del lienzo.', LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code> describe(' Descripción del lienzo.', FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+  <p>Lee ‘<a href=" /learn/accessible-labels.html "> Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
 
 line: 162
 isConstructor: false

--- a/src/content/reference/es/p5/displayHeight.mdx
+++ b/src/content/reference/es/p5/displayHeight.mdx
@@ -10,7 +10,7 @@ description: >
 line: 621
 isConstructor: false
 itemtype: property
-alt: This example does not render anything.
+alt: Este ejemplo no renderiza nada.
 example:
   - |-
 

--- a/src/content/reference/es/p5/displayHeight.mdx
+++ b/src/content/reference/es/p5/displayHeight.mdx
@@ -1,0 +1,35 @@
+---
+title: displayHeight
+module: Ambiente
+submodule: Ambiente
+file: src/core/environment.js
+description: >
+  <p>La variable <code>displayHeight</code> almacena la altura de la pantalla. Es particularmente útil para ejecutar programas en modo de pantalla completa.</p>
+  <p> Su valor depende del valor actual de  <a href="./pixelDensity">pixelDensity()</a>.</p>
+  <p>Nota: la altura de la pantalla actual se puede calcular de la siguiente manera: <code>displayHeight * pixelDensity()</code>.</p>
+line: 621
+isConstructor: false
+itemtype: property
+alt: This example does not render anything.
+example:
+  - |-
+
+    <div class="norender">
+    <code>
+    function setup() {
+      // Set the canvas' width and height
+      // using the display's dimensions.
+      createCanvas(displayWidth, displayHeight);
+
+      background(200);
+
+      describe('A gray canvas that is the same size as the display.');
+    }
+    </code>
+    </div>
+class: p5
+type: Number
+---
+
+
+# displayHeight

--- a/src/content/reference/es/p5/displayWidth.mdx
+++ b/src/content/reference/es/p5/displayWidth.mdx
@@ -1,0 +1,35 @@
+---
+title: displayWidth
+module: Ambiente
+submodule: Ambiente
+file: src/core/environment.js
+description: >
+  <p>La variable <code>displayWidth</code> almacena el ancho de la pantalla. Es particularmente útil para ejecutar programas en modo de pantalla completa.</p>
+  <p> Su valor depende del valor actual de  <a href="./pixelDensity">pixelDensity()</a>.</p>
+  <p>Nota: el ancho de la pantalla actual se puede calcular de la siguiente manera: <code>displayWidth * pixelDensity()</code>.</p>
+line: 590
+isConstructor: false
+itemtype: property
+alt: This example does not render anything.
+example:
+  - |-
+
+    <div class="norender">
+    <code>
+    function setup() {
+      // Set the canvas' width and height
+      // using the display's dimensions.
+      createCanvas(displayWidth, displayHeight);
+
+      background(200);
+
+      describe('A gray canvas that is the same size as the display.');
+    }
+    </code>
+    </div>
+class: p5
+type: Number
+---
+
+
+# displayWidth

--- a/src/content/reference/es/p5/displayWidth.mdx
+++ b/src/content/reference/es/p5/displayWidth.mdx
@@ -10,7 +10,7 @@ description: >
 line: 590
 isConstructor: false
 itemtype: property
-alt: This example does not render anything.
+alt: Este ejemplo no renderiza nada.
 example:
   - |-
 

--- a/src/content/reference/es/p5/frameCount.mdx
+++ b/src/content/reference/es/p5/frameCount.mdx
@@ -1,0 +1,61 @@
+---
+title: frameCount
+module: Ambiente
+submodule: Ambiente
+file: src/core/environment.js
+description: >
+  <p>La variable <code>frameCount</code> rastrea el número de fotogramas (frames) que se han mostrado desde que el programa comenzó a ejecutarse.</p>
+  <p>Dentro de la función <a href="./setup">setup()</a>, el valor de <code>frameCount</code> comienza en 0. Luego, cada vez que el código dentro de la función <a href="./draw">draw()</a> se ejecuta por completo,  <code>frameCount</code> incrementa en 1. </p>
+line: 69
+isConstructor: false
+itemtype: property
+example:
+  - |-
+
+    <div>
+    <code>
+    function setup() {
+      createCanvas(100, 100);
+
+      background(200);
+
+      // Display the value of
+      // frameCount.
+      textSize(30);
+      textAlign(CENTER, CENTER);
+      text(frameCount, 50, 50);
+
+      describe('The number 0 written in black in the middle of a gray square.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      createCanvas(100, 100);
+
+      // Set the frameRate to 30.
+      frameRate(30);
+
+      textSize(30);
+      textAlign(CENTER, CENTER);
+
+      describe('A number written in black in the middle of a gray square. Its value increases rapidly.');
+    }
+
+    function draw() {
+      background(200);
+
+      // Display the value of
+      // frameCount.
+      text(frameCount, 50, 50);
+    }
+    </code>
+    </div>
+class: p5
+type: Integer
+---
+
+
+# frameCount

--- a/src/content/reference/es/p5/gridOutput.mdx
+++ b/src/content/reference/es/p5/gridOutput.mdx
@@ -1,0 +1,109 @@
+---
+title: gridOutput
+module: Ambiente
+submodule: Ambiente
+file: src/accessibility/outputs.js
+description: >
+  <p><code>gridOutput()</code> genera una descripción de las formas presentes en el lienzo, la cual es accesible para lectores de pantalla, y otras tecnologías de asistencia</p>
+  <p><code>gridOutput()</code> añade una descripción general del lienzo, una lista de formas, y una tabla de formas a la página web. La descripción general incluye el tamaño del lienzo, el color del lienzo y el número de formas en el lienzo. Por ejemplo: <code>Your output is a, 100 by 100 pixels, gray canvas containing the following 2 shapes:</code> </p>
+  <p> La descripción es seguida por una lista de formas. <code>gridOutput</code> establece el contenido del lienzo a través de una cuadrícula  (tabla de html) que se basa en la posición espacial de cada forma. Cada forma se ubica en la celda correspondiente (fila y columna) según su posición en el lienzo. El lector de pantalla leerá las celdas de la cuadrícula  y describirá el color y la forma que se encuentra en cada posición. Esto es diferente de <a href="./textOutput">textOutput()</a> , que usa una lista para describir el contenido del lienzo.</p>
+  <p>Finalmente, <code>gridOutput</code> provee una lista de formas. Esta lista describe el color, la forma, la posición y el área de cada forma . Por ejemplo: <code>red circle location = middle area = 3%</code>.</p>
+  <p> El parámetro  <code>display</code> es opcional. Este parámetro determina de qué manera se va a mostrar la descripción.  Si  <code>LABEL</code> se pasa como argumento, por ejemplo: <code>gridOutput(LABEL)</code>, la descripción será visible en un elemento ‘div’ al lado del lienzo. Sin embargo, el uso de <code>LABEL</code> crea mensajes duplicados que son ineficientes para los usuarios de lectores de pantalla, por lo que recomendamos utilizar únicamente <code>LABEL</code> durante la fase de desarrollo. Por otro lado, si <code>FALLBACK</code> se pasa como argumento, por ejemplo: <code>gridOutput(FALLBACK)</code>, la descripción será visible solo para los lectores de pantalla. Este es el modo predeterminado.</p>
+  <p>Lee ‘<a href=" /learn/accessible-labels.html ">Escribiendo descripciones accesibles para lienzos</a>’ para aprender más sobre cómo hacer que tus ‘sketches’ sean accesibles.</p>
+line: 144
+isConstructor: false
+itemtype: method
+example:
+  - |-
+
+    <div>
+    <code>
+    function setup() {
+      // Add the grid description.
+      gridOutput();
+
+      // Draw a couple of shapes.
+      background(200);
+      fill(255, 0, 0);
+      circle(20, 20, 20);
+      fill(0, 0, 255);
+      square(50, 50, 50);
+
+      // Add a general description of the canvas.
+      describe('A red circle and a blue square on a gray background.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function setup() {
+      // Add the grid description and
+      // display it for debugging.
+      gridOutput(LABEL);
+
+      // Draw a couple of shapes.
+      background(200);
+      fill(255, 0, 0);
+      circle(20, 20, 20);
+      fill(0, 0, 255);
+      square(50, 50, 50);
+
+      // Add a general description of the canvas.
+      describe('A red circle and a blue square on a gray background.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function draw() {
+      // Add the grid description.
+      gridOutput();
+
+      // Draw a moving circle.
+      background(200);
+      let x = frameCount * 0.1;
+      fill(255, 0, 0);
+      circle(x, 20, 20);
+      fill(0, 0, 255);
+      square(50, 50, 50);
+
+      // Add a general description of the canvas.
+      describe('A red circle moves from left to right above a blue square.');
+    }
+    </code>
+    </div>
+
+    <div>
+    <code>
+    function draw() {
+      // Add the grid description and
+      // display it for debugging.
+      gridOutput(LABEL);
+
+      // Draw a moving circle.
+      background(200);
+      let x = frameCount * 0.1;
+      fill(255, 0, 0);
+      circle(x, 20, 20);
+      fill(0, 0, 255);
+      square(50, 50, 50);
+
+      // Add a general description of the canvas.
+      describe('A red circle moves from left to right above a blue square.');
+    }
+    </code>
+    </div>
+class: p5
+params:
+  - name: display
+    description: |
+      <p>ya sea FALLBACK o LABEL.</p>
+    type: Constant
+    optional: true
+chainable: false
+---
+
+
+# gridOutput


### PR DESCRIPTION
Añado las traducciones que se habían realizado en GitLocalize, pero que fueron ‘borradas’ por la herramienta. Las traducciones que se añaden son: 
-	describeElement()
-	describe()
-	deltaTime
-	frameCount
-	gridOutput()
-	cursor()
-	displayWidth
-	displayHeight

**El siguiente cambio se ha hecho en abs():**
- Cambiar ‘Calculo’ por ‘Calculos’.

Todo listo para revisión :)
