### PR TITLE
Ref sections

### DIFF
--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -1,6 +1,28 @@
 import { z, defineCollection } from "astro:content";
 import { relatedContent } from "../shared";
 
+// Categories, ordered in a (rough) general-to-specific sequence for easier
+// reading. Some bits that we haven't finished revising are moved lower down
+// until we revisit them.
+export const categories = [
+  'Shape',
+  'Color',
+  'Typography',
+  'Image',
+  'Transform',
+  'Environment', // TODO: make new category for accessibility
+  '3D',
+  'Rendering',
+  'Math',
+  'IO',
+  'Events',
+  'DOM',
+  'Data',
+  'Structure', // TODO: move to top once revised
+  'Constants',
+  'Foundation',
+] as const
+
 const paramSchema = z.object({
   name: z.string(),
   description: z.string(),

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -5,23 +5,23 @@ import { relatedContent } from "../shared";
 // reading. Some bits that we haven't finished revising are moved lower down
 // until we revisit them.
 export const categories = [
-  'Shape',
-  'Color',
-  'Typography',
-  'Image',
-  'Transform',
-  'Environment', // TODO: make new category for accessibility
-  '3D',
-  'Rendering',
-  'Math',
-  'IO',
-  'Events',
-  'DOM',
-  'Data',
-  'Structure', // TODO: move to top once revised
-  'Constants',
-  'Foundation',
-] as const
+  "Shape",
+  "Color",
+  "Typography",
+  "Image",
+  "Transform",
+  "Environment", // TODO: make new category for accessibility
+  "3D",
+  "Rendering",
+  "Math",
+  "IO",
+  "Events",
+  "DOM",
+  "Data",
+  "Structure", // TODO: move to top once revised
+  "Constants",
+  "Foundation",
+] as const;
 
 const paramSchema = z.object({
   name: z.string(),
@@ -65,6 +65,11 @@ export const referenceSchema = z.object({
   example: z.array(exampleSchema).optional(),
   relatedContent: relatedContent().optional(),
   methods: z.record(methodSchema).optional(),
+  isConstructor: z
+    .boolean()
+    .or(z.literal("true").transform(() => true))
+    .or(z.literal("false").transform(() => false))
+    .optional(),
 });
 
 export const referenceCollection = defineCollection({

--- a/src/content/reference/ko/p5/alpha.mdx
+++ b/src/content/reference/ko/p5/alpha.mdx
@@ -17,7 +17,7 @@ description: |2-
 
   CSS 컬러 스트링.</p>
 line: '16'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 메서드(method)
 example:
   - |-
@@ -116,7 +116,7 @@ params:
 return:
   description: 알파값(the alpha value)
   type: 숫자(Number)
-chainable: 거짓(false)
+chainable: false
 ---
 
 # 알파(alpha)

--- a/src/content/reference/ko/p5/brightness.mdx
+++ b/src/content/reference/ko/p5/brightness.mdx
@@ -28,7 +28,7 @@ description: |2-
 
   지정된 범위의 밝기 값을 반환합니다.</p>
 line: '253'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 매서드(method)
 example:
   - |-
@@ -167,7 +167,7 @@ params:
 return:
   description: 밝기값
   type: 숫자(Number)
-chainable: 거짓(false)
+chainable: false
 ---
 
 # 밝기값(brightness)

--- a/src/content/reference/ko/p5/circle.mdx
+++ b/src/content/reference/ko/p5/circle.mdx
@@ -5,7 +5,7 @@ submodule: 2D 기본
 file: src/core/shape/2d_primitives.js
 description: "\n<p>원을 그립니다.</p>\n\n\n<p>원은<code>x</code>, <code>y</code>로 정의되는 둥근 모양입니다,\n그리고<code>d</code>는 원의 지름입니다. \n\n\n매개변수. <code>x</code> 와 <code>y</code>는 중심위치를 설정합니다.\n<code>d</code> \n\n\n가 폭과 높이(지름)을 설정합니다. 원의 가장자리에 있는 모든 점은\n\n\n중심에서 동일한 거리입니다, <code>d</code>, 참조하세요.\n\n\n<a href=\"/reference/p5/ellipseMode\">ellipseMode()</a>ellipseMode설정 방법\n\n\n위치.</p>"
 line: '490'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 매서드(method)
 example:
   - |-

--- a/src/content/reference/ko/p5/color.mdx
+++ b/src/content/reference/ko/p5/color.mdx
@@ -5,7 +5,7 @@ submodule: 만들기 & 읽기
 file: src/color/creating_reading.js
 description: "\n<p> <a href=\"/reference/p5/p5.Color\">p5.Color</a> 개체를 만드세요. </p>\n\n\n<p>기본적으로, 매개변수는 RGB 값으로 해석됩니다. \n\n\n<code>color(255, 204, 0)</code> 는 밝은 노랑색을 반환합니다. 이러한\n\n\n매개변수의 해석방식은\n\n\n<a href=\"/reference/p5/colorMode\">colorMode()</a> 함수를 사용하여 변경할 수 있습니다.</p>\n\n\n<p><code>color()</code> 함수의 두가지의 매개변수 버전은 다음과 같이 해석합니다. \n\n\n매개변수가 숫자인 경우 그레이스케일 값으로 해석되고,\n\n매개변수가 문자열인 경우 CSS 색상 문자열로 해석됩니다.</p>\n\n\n<p> <code>color()</code> 또다른 두 개의 함수의 매개변수 버전에서는 첫번째를 그레이스케일 값으로 해석합니다. \n\n\n그리고 두 번째 매개변수를 알파(투명도) 값으로 설정합니다.</p>\n\n\n<p> <code>color()</code> 함수의 세 매개변수 버전은 \nRGB, HSB 또는 \n\n\n<code>colorMode()</code>에 따라 HSL 색상으로 해석합니다.</p>\n\n\n<p><code>color()</code>  함수의 네 가지 매개변수 버전은\n\n\n <code>colorMode()</code>에 따라 RGBA, HSBA,또는 HSLA 색상으로 해석합니다. \n마지막 매개변수는\n\n\n알파(투명도) 값을 설정합니다.</p>"
 line: '398'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 매서드(method)
 example:
   - |-
@@ -316,7 +316,7 @@ overloads:
     return:
       description: ''
       type: p5.Color
-chainable: 거짓(false)
+chainable: false
 ---
 
 # 색상 함수(color)

--- a/src/content/reference/ko/p5/ellipse.mdx
+++ b/src/content/reference/ko/p5/ellipse.mdx
@@ -5,7 +5,7 @@ submodule: 2D 기본
 file: src/core/shape/2d_primitives.js
 description: "\n<p>타원(Oval)을 그립니다.</p>\n\n\n<p>타원은 <code>x</code>, <code>y</code>로 정의되는 둥근 모양입니다,\n<code>w</code>, 그리고\n\n\n<code>h</code> 매개변수.\n<code>x</code> 와 <code>y</code> 가 위치를 설정합니다,\n그 중심에 <code>w</code> 와\n\n\n<code>h</code> 는 폭과 높이를 설정합니다. 참조하세요.\n\n<a href=\"/reference/p5/ellipseMode\">ellipseMode()</a> 타원모드(ellipseMode)의 위치 설정방법\n\n\n</p>\n\n\n<p>높이가 설정되지 않은 경우에 너비의 값은 너비와 높이의 값에 모두 사용됩니다. \n\n\n만약 음수 높이 또는 너비가 지정되면, 이에 대한 절대값을 사용합니다.\n\n</p>\n\n\n<p>다섯 번째 매개변수인, <code>detail</code>,도 선택사항이며, 개수를 결정합니다.\n\n\n꼭지점은 WebGL 모드에서 타원을 그리는 데 사용됩니다. 기본값은\n\n\n25입니다.</p>"
 line: '373'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 매서드(method)
 example:
   - |-

--- a/src/content/reference/ko/p5/green.mdx
+++ b/src/content/reference/ko/p5/green.mdx
@@ -5,7 +5,7 @@ submodule: 만들기 & 읽기
 file: src/color/creating_reading.js
 description: "\n<p>색상에서 초록값을 추출합니다.</p>\n\n\n<p><code>green()</code> 는 a에서 초록값을 추출합니다 \n\n<a href=\"/reference/p5/p5.Color\">p5.Color</a> 개체, 색상 배열 구성요소, \n\n\n또는 CSS 색상 문자열.</p>\n\n\n<p>기본적으로, <code>green()</code> 는 0 ~255까지 범위의 색상의 파랑값을 반환합니다.\n\n\nIf the <a href=\"/reference/colorMode\">colorMode()</a>가 RGB로 설정되어 있는 경우,\n그것을\n\n\n지정된 범위의 파랑값으로 반환합니다.</p>"
 line: '692'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: method
 example:
   - |-
@@ -131,7 +131,7 @@ params:
 return:
   description: 초록값
   type: 숫자(Number)
-chainable: 거짓(false)
+chainable: false
 ---
 
 # 초록값(green)

--- a/src/content/reference/ko/p5/hue.mdx
+++ b/src/content/reference/ko/p5/hue.mdx
@@ -5,7 +5,7 @@ submodule: 만들기 & 읽기
 file: src/color/creating_reading.js
 description: "\n<p>색상값에서 색조를 추출합니다.</p>\n\n\n<p><code>hue()</code> a에서 색조 값을 추출합니다\n\n<a href=\"/reference/p5/p5.Color\">p5.Color</a> 개체, 색상 배열\n구성요소, 또는\n\n\nCSS 색상 문자열.</p>\n\n\n<p>색조(Hue)는 컬러휠(color wheel)에서 색상의 위치를 나타냅니다. 기본적으로,\n<code>hue()</code>\n\n\n0 ~ 360 범위의 색상의 HSL 색상을 반환합니다. \n\n\n<a href=\"/reference/colorMode\">colorMode()</a>는 HSB 또는 HSL로 설정되어 있습니다\n\n\n주어진 모드에서 색조값을 되돌립니다.</p>"
 line: '828'
-isConstructor: 거짓(false)
+isConstructor: false
 itemtype: 매서드(method)
 example:
   - |-
@@ -119,7 +119,7 @@ params:
 return:
   description: 색조값
   type: 숫자(Number)
-chainable: 거짓(false)
+chainable: false
 ---
 
 # 색조값(hue)

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -12,25 +12,89 @@ interface Props {
 }
 
 const { entries } = Astro.props;
+const categoryData = categories.map((category) => {
+  const directEntries = entries.filter((e) => e.data.module === category);
+  const subcats = [
+    ...new Set(
+      directEntries
+        // Ignore classes here, they will be added later
+        .filter((e) => e.data.submodule && !e.data.isConstructor)
+        .map((e) => e.data.submodule)
+    ).values()
+  ].sort();
+  const classes = directEntries.filter(
+    (e) => e.data.isConstructor && e.data.module === category
+  ).sort((a, b) => a.name - b.name);
+
+  const subcatData = [
+    {
+      entries: directEntries.filter(
+        (e) =>
+          !e.data.submodule &&
+          // !e.data.isConstructor &&
+          !classes.some((c) => c.title === e.class)
+      )
+    },
+    ...subcats.map((subcat) => ({
+      name: subcat,
+      entries: directEntries.filter(
+        (e) =>
+          e.data.submodule === subcat &&
+          !e.data.isConstructor &&
+          !classes.some((c) => c.data.title === e.class)
+      )
+    })),
+    ...classes.map((entry) => ({
+      name: entry.data.title,
+      entry,
+      entries: directEntries.filter(
+        (e) => e.data.class === entry.data.title
+      )
+    }))
+  ]
+
+  return {
+    name: category,
+    subcats: subcatData
+  }
+});
+
 ---
 
 <BaseLayout title="Reference">
   {
-    categories.map((category) => (
+    categoryData.map((category) => (
       <>
-        <h3>{category}<a id={category}></a></h3>
-        <div class="content-grid">
-          {
-            entries.filter((e) => e.data.module === category).map((refEntry) => (
-              <div class="col-span-3 w-full overflow-hidden">
-                <a href={`/reference/${removeLocaleAndExtension(refEntry.id)}`}>
-                  {/* Needs set:html to render the entries for e.g. the > operator */}
-                  <span set:html={refEntry.data.title} />
-                </a>
+        <h3>{category.name}<a id={category.name}></a></h3>
+        {
+          category.subcats.map((subcat) => (
+            <>
+              {subcat.name && (
+                subcat.entry ? (
+                  <h4>
+                    <a id={subcat.name} href={`/reference/${removeLocaleAndExtension(subcat.entry.id)}`}>
+                      {subcat.name}
+                    </a>
+                  </h4>
+                ) : (
+                  <h4>{subcat.name}<a id={subcat.name}></a></h4>
+                )
+              )}
+              <div class="content-grid">
+                {
+                  subcat.entries.map((refEntry) => (
+                    <div class="col-span-3 w-full overflow-hidden">
+                      <a href={`/reference/${removeLocaleAndExtension(refEntry.id)}`}>
+                        {/* Needs set:html to render the entries for e.g. the > operator */}
+                        <span set:html={refEntry.data.title} />
+                      </a>
+                    </div>
+                  ))
+                }
               </div>
-            ))
-          }
-        </div>
+            </>
+          ))
+        }
       </>
     ))
   }

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -11,6 +11,16 @@ interface Props {
   entries: ReferenceEntry[];
 }
 
+function strCompare(a: string, b: string) {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
 const { entries } = Astro.props;
 const categoryData = categories.map((category) => {
   // Get all reference entries in the module
@@ -29,25 +39,28 @@ const categoryData = categories.map((category) => {
   // Find the classes in this module. These will be turned into subcategories.
   const classes = directEntries.filter(
     (e) => e.data.isConstructor && e.data.module === category
-  ).sort((a, b) => a.name - b.name);
+  ).sort((a, b) => strCompare(a.data.title, b.data.title));
 
   // Return the data for each subcategory
   const subcatData = [
     {
+      name: undefined,
+      entry: undefined,
       entries: directEntries.filter(
         (e) =>
           !e.data.submodule &&
           !e.data.isConstructor &&
-          !classes.some((c) => c.title === e.class)
+          !classes.some((c) => c.data.title === e.data.class)
       )
     },
     ...subcats.map((subcat) => ({
       name: subcat,
+      entry: undefined,
       entries: directEntries.filter(
         (e) =>
           e.data.submodule === subcat &&
           !e.data.isConstructor &&
-          !classes.some((c) => c.data.title === e.class)
+          !classes.some((c) => c.data.title === e.data.class)
       )
     })),
     ...classes.map((entry) => ({

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -13,7 +13,10 @@ interface Props {
 
 const { entries } = Astro.props;
 const categoryData = categories.map((category) => {
+  // Get all reference entries in the module
   const directEntries = entries.filter((e) => e.data.module === category);
+
+  // Get the names of all submodules
   const subcats = [
     ...new Set(
       directEntries
@@ -22,16 +25,19 @@ const categoryData = categories.map((category) => {
         .map((e) => e.data.submodule)
     ).values()
   ].sort();
+
+  // Find the classes in this module. These will be turned into subcategories.
   const classes = directEntries.filter(
     (e) => e.data.isConstructor && e.data.module === category
   ).sort((a, b) => a.name - b.name);
 
+  // Return the data for each subcategory
   const subcatData = [
     {
       entries: directEntries.filter(
         (e) =>
           !e.data.submodule &&
-          // !e.data.isConstructor &&
+          !e.data.isConstructor &&
           !classes.some((c) => c.title === e.class)
       )
     },
@@ -46,7 +52,7 @@ const categoryData = categories.map((category) => {
     })),
     ...classes.map((entry) => ({
       name: entry.data.title,
-      entry,
+      entry, // Include the class entry itself so we can make the header a link
       entries: directEntries.filter(
         (e) => e.data.class === entry.data.title
       )

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 import { removeLocaleAndExtension } from "@pages/_utils";
+import { categories } from '../content/reference/config'
 
 type ReferenceEntry = CollectionEntry<"reference">;
 
@@ -14,15 +15,23 @@ const { entries } = Astro.props;
 ---
 
 <BaseLayout title="Reference">
-  <div class="content-grid">
-    {
-      entries.map((refEntry) => (
-        <div class="col-span-3 w-full overflow-hidden">
-          <a href={`/reference/${removeLocaleAndExtension(refEntry.id)}`}>
-            {refEntry.data.title}
-          </a>
+  {
+    categories.map((category) => (
+      <>
+        <h3>{category}<a id={category}></a></h3>
+        <div class="content-grid">
+          {
+            entries.filter((e) => e.data.module === category).map((refEntry) => (
+              <div class="col-span-3 w-full overflow-hidden">
+                <a href={`/reference/${removeLocaleAndExtension(refEntry.id)}`}>
+                  {/* Needs set:html to render the entries for e.g. the > operator */}
+                  <span set:html={refEntry.data.title} />
+                </a>
+              </div>
+            ))
+          }
         </div>
-      ))
-    }
-  </div>
+      </>
+    ))
+  }
 </BaseLayout>


### PR DESCRIPTION
@stalgiag @outofambit For the reference section, we wanted to try out some slightly different structure than the existing p5.js site:
- rather than relying on an arbitrary ordering like the current site has, we have a specific order we'd like in order to show more generally relevant things first
- rather than hiding all class methods behind a class entry or search, we want to try having them visible on the reference page

I've added an array of modules in the order we want, and added a bit of code to split out the submodules + class methods. It's not pretty, but it has the category &rarr; subcategory/class &rarr; entry structure now.

<img width="1725" alt="image" src="https://github.com/bocoup/p5.js-website/assets/5315059/6f67b1a7-9043-4786-a6cb-5c3eeeb34406">
