### PR TITLE
fix image links in contributor conference docs

### DIFF
--- a/src/content/past-events/en/contributors-conference-2015.mdx
+++ b/src/content/past-events/en/contributors-conference-2015.mdx
@@ -50,8 +50,8 @@ This event was made possible by a grant from the [National Endowment for the Art
 <Logos>
     <a href="https://arts.gov/">![The National Endowment for the Arts (NEA)](../images/logo/artworks.jpg)</a>
     <a href="http://studioforcreativeinquiry.org">![The Frank-Ratchye STUDIO for Creative Inquiry](../images/logo/frank-ratchye.png)</a>
-    <a href="https://itp.nyu.edu/itp/">![NYU ITP](../logo/images/itp.png)</a>
-    <a href="http://www.du.edu/ahss/edp/">![The Emergent Digital Practices program at University of Denver](../logo/images/edp.png)</a>
-    <a href="http://bocoup.com/">![ITP](../logo/images/bocoup.png)</a>
-    <a href="http://theartificial.nl/">![The Artificial](../logo/images/theartificial.png)</a>
+    <a href="https://itp.nyu.edu/itp/">![NYU ITP](../images/logo/itp.png)</a>
+    <a href="http://www.du.edu/ahss/edp/">![The Emergent Digital Practices program at University of Denver](../images/logo/edp.png)</a>
+    <a href="http://bocoup.com/">![ITP](../images/logo/bocoup.png)</a>
+    <a href="http://theartificial.nl/">![The Artificial](../images/logo/theartificial.png)</a>
 </Logos>

--- a/src/content/past-events/en/contributors-conference-2019.mdx
+++ b/src/content/past-events/en/contributors-conference-2019.mdx
@@ -75,7 +75,7 @@ This event was made possible by a grant from the <a href="https://arts.gov/" tar
 **Thank you!**
 
 <Logos>
-    <a href="https://arts.gov/">![The National Endowment for the Arts (NEA)](../images/logo/logo/artworks.jpg)</a>
+    <a href="https://arts.gov/">![The National Endowment for the Arts (NEA)](../images/logo/artworks.jpg)</a>
     <a href="http://studioforcreativeinquiry.org">![The Frank-Ratchye STUDIO for Creative Inquiry](../images/logo/frank-ratchye.png)</a>
     <a href="http://thebaselschoolofdesign.ch/">![University of Applied Sciences and Arts Northwestern Switzerland Academy of Arts and Design](../images/logo/northwestern-switzerland.jpg)</a>
     <a href="http://foundation.processing.org/">![Processing Foundation](../images/logo/processing-foundation.png)</a>


### PR DESCRIPTION
introduced in 673e173 (i think), which broke the build. doing a quick fix here!