### PR TITLE
Enable CI workflows to run on PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test, typecheck, and lint
 
 on:
-  push:
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
closes #91 

we were using the `push` trigger which doesn't work for PRs from forks. using the `pull request` trigger should fix that.