### PR TITLE
Escape html inside of code tags in reference descriptions

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -1,14 +1,17 @@
 ---
 import CodeEmbed from "@components/CodeEmbed";
 import { getCurrentLocale, useTranslations } from "@i18n/utils";
-import { separateReferenceExamples } from "@pages/_utils";
+import {
+  escapeCodeTagsContent,
+  separateReferenceExamples,
+} from "@pages/_utils";
 import BaseLayout from "./BaseLayout.astro";
 import MethodSignature from "@components/MethodSignature/index.astro";
 import type { ReferenceParam } from "@/types/parsers.interface";
 
 const { entry } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url.pathname);
-
+const description = escapeCodeTagsContent(entry.data.description);
 const examples = separateReferenceExamples(entry.data.example);
 const t = await useTranslations(currentLocale);
 ---
@@ -16,10 +19,7 @@ const t = await useTranslations(currentLocale);
 <BaseLayout title={entry.data.title} variant="item">
   <div class="content-grid mt-0">
     <div class="col-span-9">
-      <div
-        set:html={entry.data.description}
-        class="[&_a]:text-type-magenta mb-xl"
-      />
+      <div set:html={description} class="[&_a]:text-type-magenta mb-xl" />
       {
         examples && (
           <div class="mb-xl">

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -6,6 +6,8 @@ import {
 } from "astro:content";
 import { defaultLocale } from "@i18n/const";
 import { removeLocalePrefix, startsWithSupportedLocale } from "@i18n/utils";
+import { load } from "cheerio";
+import he from "he";
 
 /**
  * Retreives all the entries in the given collection, filtered to only include
@@ -160,3 +162,24 @@ export const separateReferenceExamples = (examples: string[]): string[] =>
     ?.flatMap((example: string) => example.split("</div>"))
     .map((htmlFrag: string) => htmlFrag.replace(/<\/?div>|<\/?code>/g, ""))
     .filter((cleanExample: string) => cleanExample);
+
+/**
+ * Function to escape HTML content within <code> tags
+ * @param htmlString String with HTML content
+ * @returns String with HTML content where the content inside <code> tags is escaped
+ */
+export const escapeCodeTagsContent = (htmlString: string): string => {
+  // Load the HTML string into Cheerio
+  const $ = load(htmlString);
+  // Loop through all <code> tags
+  $("code").each(function () {
+    // Get the current text and HTML inside the <code> tag
+    const currentHtml = $(this).html() ?? "";
+    // Use he to escape HTML entities
+    const escapedHtml = he.escape(currentHtml);
+    // Update the <code> tag content with the escaped HTML
+    $(this).html(escapedHtml);
+  });
+  // Return the modified HTML as a string
+  return $.html();
+};


### PR DESCRIPTION
This fixes #95 

This may be needed elsewhere but applying here for now.