### PR TITLE
Update tutorials to correctly reference examples/references

### DIFF
--- a/src/components/EditableSketch/index.astro
+++ b/src/components/EditableSketch/index.astro
@@ -11,7 +11,7 @@ const { props } = Astro;
 
 let previewWidth = props.previewWidth;
 let previewHeight = props.previewHeight;
-const match = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:P2D|WEBGL\s*)?\)/m.exec(props.code);
+const match = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:P2D|WEBGL)\s*)?\)/m.exec(props.code);
 if (match) {
   previewWidth = previewWidth || parseFloat(match[1]);
   previewHeight = previewHeight || parseFloat(match[2]);

--- a/src/content/tutorials/en/animating-with-media-objects.mdx
+++ b/src/content/tutorials/en/animating-with-media-objects.mdx
@@ -5,15 +5,16 @@ description: Learn how to load images and GIFs to your sketches by creating an i
 category: introduction
 featuredImage: ../images/featured/media.png
 featuredImageAlt: A still frame from an animation of three flowers with petals illustrated using pointillism, three solid stems, and a watering pot.
-relatedExamples:
-  - 12_Advanced_Canvas_Rendering/00_Create_Graphics
-relatedReferences:
-  - p5/loadImage
-  - p5/createGraphics
-  - p5.Image
-  - p5.Image/pause
-  - p5.Image/play
-  - p5/image
+relatedContent:
+  examples:
+    - en/12_advanced_canvas_rendering/00_create_graphics/description
+  references:
+    - en/p5/loadimage
+    - en/p5/creategraphics
+    - en/p5/p5image
+    - en/p5image/pause
+    - en/p5image/play
+    - en/p5/image
 authors:
   - Joanne Amarisa
   - Jaleesa Trapp
@@ -32,9 +33,9 @@ p5.js makes it fun and simple to draw, color and animate shapes on an HTML canva
 
 Image and GIF files contain information that can be used to display or modify them in a p5.js project. In this tutorial you will create an [interactive animation](https://editor.p5js.org/joanneamarisa/sketches/PFmWqy0qB) using media and learn to: 
 
-- Upload and display image files in a p5.js sketch using the [`preload()`](/reference/p5/preload) function and [`p5.Image`](/reference/p5.Image) objects
-- Adjust the appearance of image files in p5.js using [`p5.Image`](/reference/p5.Image) methods for sizing, positioning, an styling
-- Interact with [`p5.Image`](/reference/p5.Image) objects 
+- Upload and display image files in a p5.js sketch using the [`preload()`](/reference/p5/preload) function and [`p5.Image`](/reference/p5/p5.Image) objects
+- Adjust the appearance of image files in p5.js using [`p5.Image`](/reference/p5/p5.Image) methods for sizing, positioning, an styling
+- Interact with [`p5.Image`](/reference/p5/p5.Image) objects 
 - Create an extra drawing surface using [`createGraphics()`](/reference/p5/createGraphics)
 - Save the sketch as a GIF file to your device
 
@@ -124,7 +125,7 @@ function preload() {
 
 ### [`loadImage()`](/reference/p5/loadImage)
 
-`loadImage()` follows a path to an image in its located folder, and loads it into memory as a [`p5.Image`](/reference/p5.Image) object. `p5.Image` is an *object* that stores image information. There are many data types in p5.js including integers, Booleans and strings. Later in this tutorial, we’ll explore together how p5.js functions can use that image data.
+`loadImage()` follows a path to an image in its located folder, and loads it into memory as a [`p5.Image`](/reference/p5/p5.Image) object. `p5.Image` is an *object* that stores image information. There are many data types in p5.js including integers, Booleans and strings. Later in this tutorial, we’ll explore together how p5.js functions can use that image data.
 
 To load an image, call `loadImage()` with one string argument containing the filename of the image. For example, `loadImage("flower-1.png");`.
 
@@ -259,11 +260,11 @@ function draw() {
 
 
 
-### [`p5.Image` Methods](/reference/p5.Image)
+### [`p5.Image` Methods](/reference/p5/p5.Image)
 
 To resize `flower1,` we used the line `flower1.resize(100,100)`. `resize()` is called a *method* because it is a special function that operates on objects. Each object data type has a set of methods that are available to use. You can call methods by typing a dot “.” after the object name followed by the name of the method. `resize()` is one of the methods you can use with `p5.Image` objects. There are many other methods to process or manipulate the pixels of an image.
 
-Visit the [`p5.Image` Reference page](/reference/p5.Image) to explore other methods for modifying the appearance of an image.
+Visit the [`p5.Image` Reference page](/reference/p5/p5.Image) to explore other methods for modifying the appearance of an image.
 
 <Callout>
 What happens when you try the `p5.Image.filter()` methods below? Add them to your sketch in `setup()`.
@@ -800,7 +801,7 @@ function draw() {
 
 ### 8.2 – Create a new `p5.Graphics` object
 
-We’ll start by creating a new [`p5.Graphics`](/reference/p5.Graphics) buffer object. A graphics buffer is similar to creating a new canvas. This allows us to display multiple layers of graphics information on the canvas. For example, in our current sketch, we will use a graphics object to separate our static canvas from the pointillist flowers. When we refresh the canvas background, the pointillist painting will not reset, and continues to develop.
+We’ll start by creating a new [`p5.Graphics`](/reference/p5/p5.Graphics) buffer object. A graphics buffer is similar to creating a new canvas. This allows us to display multiple layers of graphics information on the canvas. For example, in our current sketch, we will use a graphics object to separate our static canvas from the pointillist flowers. When we refresh the canvas background, the pointillist painting will not reset, and continues to develop.
 
 .![Image showing the canvas background containing the flower stems and watering can and the graphics object containing the three flowers.](../images/introduction/graphics-diagram.jpg) 
 
@@ -856,7 +857,7 @@ From this point onwards, every function we want to render onto the `p5.Graphics`
 
 We will be drawing our pointillism effect to the graphics object. Note that this is advantageous because when we refresh the background of the canvas, the garden object does not get refreshed, and we can continue adding pointillist dots to the graphics object.
 
-You can visit the p5.js Reference to learn more about [`p5.Graphics` objects.](/reference/p5.Graphics)
+You can visit the p5.js Reference to learn more about [`p5.Graphics` objects.](/reference/p5/p5.Graphics)
 
 
 ### 8.3 – Source the pixel colors from the image

--- a/src/content/tutorials/en/color-gradients.mdx
+++ b/src/content/tutorials/en/color-gradients.mdx
@@ -5,17 +5,18 @@ description: Use radial gradients, linear gradients, and blend modes to create l
 category: drawing
 featuredImage: ../images/featured/ColorGradientsA.png
 featuredImageAlt: A webcam snapshot of a white person with short dark curly hair wearing pink heart shaped glasses posing for a picture. There is a red to yellow linear gradient filter on top of the photo. Colorful circles are scattered on top of the image with a color gradient overlay. The circles have randomized radial color gradients inside them to mimic a camera's lens flare. Some color gradients are pink to purple, cyan to green, or yellow to orange.
-relatedReferences:
-  - p5/createCapture
-  - p5/createButton
-  - p5/colorMode
-  - p5/blendMode
-  - p5/map
-  - p5/lerpColor
-relatedExamples:
-  - 04_Input_Elements/01_Input_Button
-  - 07_Repetition/00_Color_Interpolation
-  - 07_Repetition/01_Color_Wheel
+relatedContent:
+  references:
+    - en/p5/createcapture
+    - en/p5/createbutton
+    - en/p5/colormode
+    - en/p5/blendmode
+    - en/p5/map
+    - en/p5/lerpcolor
+  examples:
+    - en/04_input_elements/01_input_button/description
+    - en/07_repetition/00_color_interpolation/description
+    - en/07_repetition/01_color_wheel/description
 authors:
   - Jules Kris
   - Tristan Bunn
@@ -50,12 +51,12 @@ This tutorial uses the [p5.js Web Editor](https://editor.p5js.org/) and is desig
   - Call `createCanvas(640, 480)`.
   - Declare a global variable called `video` using the keyword `let`. You’ll assign a value to this shortly.
   - In your `setup()` function, assign a `createCapture(VIDEO)` object to your `video` variable by adding: `video = createCapture(VIDEO)`.
-    - This will initialize a [`p5.MediaElement`](/reference/p5.MediaElement) with your webcam to feed the video from your webcam into your sketch using the `video `variable.
-    - Visit the p5.js reference pages for [`let`](/reference/p5/let), [`createCapture()`](/reference/p5/createCapture), and [`p5.MediaElement`](/reference/p5.MediaElement) to learn more.
+    - This will initialize a [`p5.MediaElement`](/reference/p5/p5.MediaElement) with your webcam to feed the video from your webcam into your sketch using the `video `variable.
+    - Visit the p5.js reference pages for [`let`](/reference/p5/let), [`createCapture()`](/reference/p5/createCapture), and [`p5.MediaElement`](/reference/p5/p5.MediaElement) to learn more.
   - Set the position to (0, 0), pinning it to the top left of your canvas, using the `.position()` method by adding `.position(0, 0)` in `setup()`.
     - If you run the sketch now, you should see the video feed from your webcam appear in the preview window. 
     - See this [example sketch](https://editor.p5js.org/Msqcoding/sketches/mLfhMChZW) that sets up your webcam to display on the canvas. 
-    - Visit the p5.reference pages for [`.position()`](/reference/p5.Element/position) and [`p5.Element`](/reference/p5.Element) to learn more.
+    - Visit the p5.reference pages for [`.position()`](/reference/p5.Element/position) and [`p5.Element`](/reference/p5/p5.Element) to learn more.
 - Create a function to take a snapshot with your webcam.
   - Declare a global [Boolean](/reference/p5/boolean) variable called `snapped` and assign it a value of `false`.
     - This variable will keep track of when a snapshot is taken and is known as a [state](https://developer.mozilla.org/en-US/docs/Glossary/State_machine) variable.

--- a/src/content/tutorials/en/conditionals-and-interactivity.mdx
+++ b/src/content/tutorials/en/conditionals-and-interactivity.mdx
@@ -5,14 +5,15 @@ description: A tutorial on how to use conditional statements and make interactiv
 category: introduction
 featuredImage: ../images/featured/ConditionalsA.png
 featuredImageAlt: A preview of the sunrise animation created in the Conditionals and Interactivity tutorial.
-relatedExamples:
-  - 11_3D/06_Framebuffer_Blur
-relatedReferences:
-  - p5/if-else
-  - p5/boolean
-  - p5/mouseIsPressed
-  - p5/keyCode
-  - p5/circle
+relatedContent:
+  examples:
+    - en/11_3d/06_framebuffer_blur/description
+  references:
+    - en/p5/if-else
+    - en/p5/boolean
+    - en/p5/mouseispressed
+    - en/p5/keycode
+    - en/p5/circle
 authors:
   - Greg Benedis-Grab
   - Layla Quiñones

--- a/src/content/tutorials/en/coordinates-and-transformations.mdx
+++ b/src/content/tutorials/en/coordinates-and-transformations.mdx
@@ -5,16 +5,17 @@ description: An overview of the different ways you can position objects in WebGL
 category: webgl
 featuredImage: ../images/featured/coordinates-and-transformations.jpg
 featuredImageAlt: A cube on top of a grid with colored lines showing its movement in 3D space.
-relatedExamples:
-  - 05_Transformation/00_Translate
-  - 05_Transformation/01_Rotate
-  - 05_Transformation/02_Scale
-relatedReferences:
-  - p5/translate
-  - p5/rotate
-  - p5/scale
-  - p5/push
-  - p5/pop
+relatedContent:
+  examples:
+    - en/05_transformation/00_translate/description
+    - en/05_transformation/01_rotate/description
+    - en/05_transformation/02_scale/description
+  references:
+    - en/p5/translate
+    - en/p5/rotate
+    - en/p5/scale
+    - en/p5/push
+    - en/p5/pop
 authors:
   - Dave Pagurek
   - Austin Lee Slominski

--- a/src/content/tutorials/en/creating-styling-html.mdx
+++ b/src/content/tutorials/en/creating-styling-html.mdx
@@ -5,11 +5,12 @@ description: Dive into the art of creative coding and learn to build and beautif
 category: web-design
 featuredImage: ../images/featured/HtmlA.png
 featuredImageAlt: A graphic illustration of a code editor with colorful lines that suggest syntax highlighting code. Two floating circles resembling HTML tags surround the editor.
-relatedReferences:
-  - p5.Element
-  - p5.Element/style
-  - p5/select
-  - p5/createDiv
+relatedContent:
+  references:
+    - en/p5/p5element
+    - en/p5element/style
+    - en/p5/select
+    - en/p5/creatediv
 authors:
   - Ruth Ikegah
   - Jules Kris
@@ -17,7 +18,7 @@ authors:
 
 import { Callout } from "../../../components/Callout/";
 
-This tutorial provides a practical approach to learning how to use the core concepts of p5.js and the [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) by building a simple [Game Boy](https://en.wikipedia.org/wiki/Game_Boy) emulator in the [p5.js Web Editor](https://editor.p5js.org/). You'll learn how p5.js works with HTML and CSS, its architecture, and [`p5.Element`](/reference/p5.Element) functions for creating and styling HTML elements. At the end of this tutorial, you will successfully develop a [retro-style](https://en.wikipedia.org/wiki/Retro_style) Game Boy emulator capable of running a basic snake game.
+This tutorial provides a practical approach to learning how to use the core concepts of p5.js and the [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) by building a simple [Game Boy](https://en.wikipedia.org/wiki/Game_Boy) emulator in the [p5.js Web Editor](https://editor.p5js.org/). You'll learn how p5.js works with HTML and CSS, its architecture, and [`p5.Element`](/reference/p5/p5.Element) functions for creating and styling HTML elements. At the end of this tutorial, you will successfully develop a [retro-style](https://en.wikipedia.org/wiki/Retro_style) Game Boy emulator capable of running a basic snake game.
 
 This tutorial is the first in a series of tutorials on [Web Design](https://drive.google.com/open?id=1UiEb9ujbVAuzg_WaLy22OVOH4zWuB-f3). Check out the [final sketch example](https://editor.p5js.org/ruthikegah/sketches/sf6K_7QzP) you will complete at the end of the [Web Design](https://drive.google.com/open?id=1UiEb9ujbVAuzg_WaLy22OVOH4zWuB-f3) tutorial series! 
 
@@ -256,11 +257,11 @@ Your canvas should look like this: 
 
 In the code above, you declared the variables `winWidth` and `winHeight`, and initialized them with 400 and 300, respectively. These variables represent the initial width and height of the canvas.
 
-The `setup()` function is called once at the beginning of a sketch, and is used to define the initial environment properties. This can include setting the screen size, background color, and loading the media you want to use in your project. The canvas [p5.Element](/reference/p5.Element) object is stored in the variable `canvas`.
+The `setup()` function is called once at the beginning of a sketch, and is used to define the initial environment properties. This can include setting the screen size, background color, and loading the media you want to use in your project. The canvas [p5.Element](/reference/p5/p5.Element) object is stored in the variable `canvas`.
 
 The `draw()` function runs in a continuous loop after the `setup()` function. Within this loop, the background color of the canvas is set to a dark gray shade using the `background(51)`. This function clears the canvas before each frame is drawn, maintaining a consistent background for an ongoing animation.
 
-To learn more, visit the p5.js reference for [`setup()`](/reference/p5/setup), [createCanvas()](/reference/p5/createCanvas) and [p5.Element](/reference/p5.Element)
+To learn more, visit the p5.js reference for [`setup()`](/reference/p5/setup), [createCanvas()](/reference/p5/createCanvas) and [p5.Element](/reference/p5/p5.Element)
 
 <Callout>
 Add a shadow to your canvas using a CSS property.
@@ -328,7 +329,7 @@ Your preview should look like this:
 
 ### `p5.Element`
 
-In this step, you use [`p5.Element`](/reference/p5.Element) objects to create HTML elements. A `p5.Element` allows standard HTML elements to be added to the HTML in `sketch.js`. All HTML elements share the functions of the `p5.Element` class. Some of these elements include  [`createCanvas()`](/reference/p5/createCanvas), [`createDiv()`](/reference/p5/createDiv), [`createP()`](/reference/p5/createP) and [`createButton()`](/reference/p5/createButton). Some functions that can be used with `p5.Element` objects are [`.id()`](/reference/p5.Element/id),  [`.child()`](/reference/p5.Element/child), [`.style()`](/reference/p5.Element/style), [`.position()`](/reference/p5.Element/position) and [`.size()`](/reference/p5.Element/size).
+In this step, you use [`p5.Element`](/reference/p5/p5.Element) objects to create HTML elements. A `p5.Element` allows standard HTML elements to be added to the HTML in `sketch.js`. All HTML elements share the functions of the `p5.Element` class. Some of these elements include  [`createCanvas()`](/reference/p5/createCanvas), [`createDiv()`](/reference/p5/createDiv), [`createP()`](/reference/p5/createP) and [`createButton()`](/reference/p5/createButton). Some functions that can be used with `p5.Element` objects are [`.id()`](/reference/p5.Element/id),  [`.child()`](/reference/p5.Element/child), [`.style()`](/reference/p5.Element/style), [`.position()`](/reference/p5.Element/position) and [`.size()`](/reference/p5.Element/size).
 
 In `setup()`, you declared a variable called `gameBoyEmulator` and assigned it to a new `<div>` `p5.Element` created with the [`createDiv()`](/reference/p5/createDiv) function. You then gave the `gameBoyEmulator` an id attribute `"game-boy-emulator"` by calling its `.id()` method.
 

--- a/src/content/tutorials/en/custom-geometry.mdx
+++ b/src/content/tutorials/en/custom-geometry.mdx
@@ -5,14 +5,15 @@ description: A guide to the different ways you can create your own 3D shapes.
 category: webgl
 featuredImage: ../images/featured/custom-geometry.png
 featuredImageAlt: A bunch of red ladybugs on a green background
-relatedExamples:
-  - 11_3D/00_Geometries
-  - 11_3D/01_Custom_Geometry
-relatedReferences:
-  - p5/loadModel
-  - p5/buildGeometry
-  - p5/model
-  - p5.Geometry
+relatedContent:
+  examples:
+    - en/11_3d/00_geometries/description
+    - en/11_3d/01_custom_geometry/description
+  references:
+    - en/p5/loadmodel
+    - en/p5/buildgeometry
+    - en/p5/model
+    - en/p5/p5geometry
 authors:
   - Dave Pagurek
   - Austin Lee Slominski

--- a/src/content/tutorials/en/custom-shapes-and-smooth-curves.mdx
+++ b/src/content/tutorials/en/custom-shapes-and-smooth-curves.mdx
@@ -5,14 +5,15 @@ description: Use vertex(), bezierVertex(), beginShape() and endShape() to create
 category: drawing
 featuredImage: ../images/featured/CustomShapesSmoothCurvesA.png
 featuredImageAlt: A white person with short, dark curly hair wears pink heart-shaped glasses and a dark sleeveless shirt. He places his hand on his cheek and looks diagonally to the left, smiling softly. A vertical linear blue to pink gradient is overlaid. On top of that, we see a mixture of angular and curved white 4-pointed sparkles of varying sizes, with an angular sparkle over the left lens of his glasses, and a curved sparkle over the right lens. We see pink and blue radial gradient circles layered on top, creating a lens flare effect.
-relatedReferences:
-  - p5/vertex
-  - p5/bezierVertex
-  - p5/beginShape
-  - p5/endShape
-  - p5/translate
-relatedExamples:
-  - 07_Repetition/02_Bezier
+relatedContent:
+  references:
+    - en/p5/vertex
+    - en/p5/beziervertex
+    - en/p5/beginshape
+    - en/p5/endshape
+    - en/p5/translate
+  examples:
+    - en/07_repetition/02_bezier/description
 authors:
   - Jules Kris
   - Tristan Bunn

--- a/src/content/tutorials/en/data-structure-garden.mdx
+++ b/src/content/tutorials/en/data-structure-garden.mdx
@@ -5,15 +5,16 @@ description: A tutorial on how to use JavaScript objects and arrays.
 category: introduction
 featuredImage: ../images/featured/DataStructuresGardenA.png
 featuredImageAlt: A preview of the interactive flower garden with flowers appearing on a light blue canvas as a user clicks with their mouse pointer.
-relatedExamples:
-  - 13_Classes_And_Objects/00_Snowflakes
-  - 13_Classes_And_Objects/01_Shake_Ball_Bounce
-  - 13_Classes_And_Objects/02_Connected_Particles
-relatedReferences:
-  - p5/console/log
-  - p5/object
-  - p5/return
-  - p5/random
+relatedContent:
+  examples:
+    - en/13_classes_and_objects/00_snowflakes/description
+    - en/13_classes_and_objects/01_shake_ball_bounce/description
+    - en/13_classes_and_objects/02_connected_particles/description
+  references:
+    - en/console/log
+    - en/p5/object
+    - en/p5/return
+    - en/p5/random
 authors:
   - Portia Morrell
   - Jaleesa Trapp

--- a/src/content/tutorials/en/field-guide-to-debugging.mdx
+++ b/src/content/tutorials/en/field-guide-to-debugging.mdx
@@ -5,8 +5,9 @@ description: Learn some healthy habits and best practices for  locating bugs in 
 category: advanced
 featuredImage: ../images/featured/FieldGuide.png
 featuredImageAlt: "The title is “A Field Guide to Debugging!” and it features a black-and-white cartoon illustrations of insects, a mouse and a computer laptop in deep thought."
-relatedReferences:
-  - console/log
+relatedContent:
+  references:
+    - en/console/log
 authors:
   - Nick McIntyre
   - Jason Alderman

--- a/src/content/tutorials/en/get-started.mdx
+++ b/src/content/tutorials/en/get-started.mdx
@@ -5,13 +5,14 @@ description: A tutorial that introduces basic p5.js functions and guides you thr
 category: introduction
 featuredImage: ../images/featured/GetStartedA.png
 featuredImageAlt: A preview of the interactive landscape project showing a ladybug and flower emoji in front of a simple landscape background.
-relatedExamples:
-  - 01_Shapes_And_Color/00_Shape_Primitives
-  - 01_Shapes_And_Color/01_Color
-relatedReferences:
-  - p5/background
-  - p5/fill
-  - p5/text
+relatedContent:
+  examples:
+    - en/01_shapes_and_color/00_shape_primitives/description
+    - en/01_shapes_and_color/01_color/description
+  references:
+    - en/p5/background
+    - en/p5/fill
+    - en/p5/text
 authors:
   - Layla Quiñones
   - Jaleesa Trapp

--- a/src/content/tutorials/en/getting-started-with-nodejs.mdx
+++ b/src/content/tutorials/en/getting-started-with-nodejs.mdx
@@ -5,9 +5,10 @@ description: Learn about HTTP requests and how to use Node.js in your p5.js proj
 category: advanced
 featuredImage: ../images/featured/node.png
 featuredImageAlt: A p5.js logo with musical notes above it has arrows labeled with HTTP methods pointing to a cloud labeled “Internet”. Above the cloud is an icon that reads “http\://”. Arrows point from the cloud to a pink cube labeled “Web Server” with the Node.js logo above it.
-relatedReferences:
-  - p5/preload
-  - p5/loadJSON
+relatedContent:
+  references:
+   - en/p5/preload
+   - en/p5/loadjson
 authors:
   - Layla Quiñones
   - Nick McIntyre

--- a/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
+++ b/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
@@ -5,13 +5,14 @@ description: An advanced tutorial on how to optimize code in your sketches to ru
 category: advanced
 featuredImage: ../images/featured/OptimizeA.png
 featuredImageAlt: The bouncing particles animation used in this tutorial displays orange circles bouncing around a dark canvas.
-relatedReferences:
-  - console/log
-  - p5/frameRate
-  - p5/millis
-  - p5/min
-  - p5.Vector
-  - p5.Image
+relatedContent:
+  references:
+    - en/console/log
+    - en/p5/framerate
+    - en/p5/millis
+    - en/p5/min
+    - en/p5/p5vector
+    - en/p5/p5image
 authors:
   - Greg Benedis-Grab
   - Dave Pagurek
@@ -350,7 +351,7 @@ When looping through the pixels in an image, you can get an easy performance boo
 You have several options when it comes to resizing and sampling:
 
 - Resize the image before importing by using an app such as Photoshop or [GIMP](https://www.gimp.org/tutorials/GIMP_Quickies/#changing-the-size-dimensions-of-an-image-scale). This will likely result in the best quality image because you can control the resizing algorithm and apply filters to sharpen the image.
-- Resize the image using [`p5.Image`](/reference/p5.Image)’s [`resize()`](/reference/p5.Image/resize) method. Here, you are mostly at the whim of the browser for how it handles resizing. Check out MDN for more info on [image rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering).
+- Resize the image using [`p5.Image`](/reference/p5/p5.Image)’s [`resize()`](/reference/p5.Image/resize) method. Here, you are mostly at the whim of the browser for how it handles resizing. Check out MDN for more info on [image rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering).
 - Sample the image by only drawing every 2nd (or 3rd or 4th, etc.) pixel from the original image. Dead simple and effective, but you can potentially lose thin details in the image if you skip a lot of pixels.
 - Practically speaking, these appear to have roughly the same performance. Resizing the image beforehand gives you the most control over the final visuals. If you can’t resize, sampling or resizing in the sketch may serve you well.
 - One last note! If you are doing drastic resizing of an image or you have an image with important fine details, sampling or resizing can give pretty poor results.

--- a/src/content/tutorials/en/intro-to-shaders.mdx
+++ b/src/content/tutorials/en/intro-to-shaders.mdx
@@ -5,14 +5,15 @@ description: An introduction to the different ways you can create interesting vi
 category: webgl
 featuredImage: ../images/featured/intro-to-shaders.jpg
 featuredImageAlt: A warped, wavy city street
-relatedExamples:
-  - 11_3D/04_Filter_Shader
-  - 11_3D/05_Adjusting_Positions_With_A_Shader
-  - 11_3D/06_Framebuffer_Blur
-relatedReferences:
-  - p5/createFilterShader
-  - p5/loadShader
-  - p5.Shader
+relatedContent:
+  examples:
+    - en/11_3d/04_filter_shader/description
+    - en/11_3d/05_adjusting_positions_with_a_shader/description
+    - en/11_3d/06_framebuffer_blur/description
+  references:
+    - en/p5/createfiltershader
+    - en/p5/loadshader
+    - en/p5/p5shader
 authors:
   - Dave Pagurek
   - Austin Lee Slominski

--- a/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
+++ b/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
@@ -5,12 +5,13 @@ description: Framebuffers are the fastest way to create a scene out of multiple 
 category: webgl
 featuredImage: ../images/featured/layered-rendering-with-framebuffers.png
 featuredImageAlt: A line of spheres receding into fog as they go off into the distance
-relatedExamples:
-  - 11_3D/06_Framebuffer_Blur
-relatedReferences:
-  - p5/createFramebuffer
-  - p5.Framebuffer
-  - p5/clearDepth
+relatedContent:
+  examples:
+    - en/11_3d/06_framebuffer_blur/description
+  references:
+    - en/p5/createframebuffer
+    - en/p5/p5framebuffer
+    - en/p5/cleardepth
 authors:
   - Dave Pagurek
   - Adam Ferriss

--- a/src/content/tutorials/en/lights-camera-materials.mdx
+++ b/src/content/tutorials/en/lights-camera-materials.mdx
@@ -5,23 +5,24 @@ description: TODO
 category: webgl
 featuredImage: ../images/featured/lights-camera-material.jpg
 featuredImageAlt: A sphere in front of some walls and a floor, lit by a red, green, and blue light.
-relatedExamples:
-  - 11_3D/02_Materials
-  - 11_3D/03_Orbit_Control
-relatedReferences:
-  - p5/camera
-  - p5/perspective
-  - p5/ortho
-  - p5/ambientLight
-  - p5/directionalLight
-  - p5/spotLight
-  - p5/pointLight
-  - p5/imageLight
-  - p5/fill
-  - p5/ambientMaterial
-  - p5/specularMaterial
-  - p5/emissiveMaterial
-  - p5/shininess
+relatedcontent:
+  examples:
+    - en/11_3d/02_materials/description
+    - en/11_3d/03_orbit_control/description
+  references:
+    - en/p5/camera
+    - en/p5/perspective
+    - en/p5/ortho
+    - en/p5/ambientlight
+    - en/p5/directionallight
+    - en/p5/spotlight
+    - en/p5/pointlight
+    - en/p5/imagelight
+    - en/p5/fill
+    - en/p5/ambientmaterial
+    - en/p5/specularmaterial
+    - en/p5/emissivematerial
+    - en/p5/shininess
 authors:
   - Dave Pagurek
   - Austin Lee Slominski

--- a/src/content/tutorials/en/loading-and-selecting-fonts.mdx
+++ b/src/content/tutorials/en/loading-and-selecting-fonts.mdx
@@ -5,13 +5,14 @@ description: "Explore typography in creative coding: A Quick guide to choosing a
 category: web-design
 featuredImage: ../images/featured/FontsA.png
 featuredImageAlt: "Bold typography in contrasting white and black against a deep blue background. It features the words 'FONTSTYLE' in black at the top. 'TYPEFACE' is in white in the middle. 'abc' is in white at the bottom. Each is in a different font size. This creates a bold and striking display of font styles and typefaces."
-relatedReferences:
-  - p5/preload
-  - p5/loadFont
-  - p5/textFont
-  - p5/text
-  - p5.Font
-  - p5.Element/style
+relatedContent:
+  references:
+    - en/p5/preload
+    - en/p5/loadfont
+    - en/p5/textfont
+    - en/p5/text
+    - en/p5/p5font
+    - en/p5element/style
 authors:
   - Ruth Ikegah
   - Jules Kris

--- a/src/content/tutorials/en/optimizing-webgl-sketches.mdx
+++ b/src/content/tutorials/en/optimizing-webgl-sketches.mdx
@@ -5,13 +5,14 @@ description: Tips to help make your sketches run as smoothly as possible on as m
 category: webgl
 featuredImage: ../images/featured/optimizing-webgl-sketches.png
 featuredImageAlt: A screenshot of the profiler in the developer tools of Google Chrome
-relatedExamples:
-  - 11_3D/04_Filter_Shader
-relatedReferences:
-  - p5/createFramebuffer
-  - p5.Framebuffer
-  - p5/createFilterShader
-  - p5.Shader
+relatedContent:
+  examples:
+    - en/11_3d/04_filter_shader/description
+  references:
+    - en/p5/createframebuffer
+    - en/p5/p5framebuffer
+    - en/p5/createfiltershader
+    - en/p5/p5shader
 authors:
   - Dave Pagurek
   - Adam Ferriss

--- a/src/content/tutorials/en/organizing-code-with-functions.mdx
+++ b/src/content/tutorials/en/organizing-code-with-functions.mdx
@@ -5,11 +5,12 @@ description: A tutorial on how to create and use functions to help you organize 
 category: introduction
 featuredImage: ../images/featured/FunctionsA.png
 featuredImageAlt: A canvas displaying a snapshot of the sunrise animation from the Conditionals and Interactivity tutorial. The snapshot includes a sun, and trees and mountains in the landscape.
-relatedReferences:
-  - p5/function
-  - p5/return
-  - p5/keyPressed
-  - p5/mousePressed
+relatedContent:
+  references:
+    - en/p5/function
+    - en/p5/return
+    - en/p5/keypressed
+    - en/p5/mousepressed
 authors:
   - Greg Benedis-Grab
   - Layla Quiñones

--- a/src/content/tutorials/en/repeating-with-loops.mdx
+++ b/src/content/tutorials/en/repeating-with-loops.mdx
@@ -5,10 +5,11 @@ description: "Create a crawling caterpillar race using loops and arrays!"
 category: introduction
 featuredImage: ../images/featured/loops.png
 featuredImageAlt: Three pink caterpillars with googly eyes on the starting line wait for the race with the text “Click to start”.
-relatedReferences:
-  - p5/for
-  - p5/noLoop
-  - p5/random
+relatedContent:
+  references:
+    - en/p5/for
+    - en/p5/noloop
+    - en/p5/random
 authors:
   - Joanne Amarisa
   - Layla Quiñones

--- a/src/content/tutorials/en/responding-to-inputs.mdx
+++ b/src/content/tutorials/en/responding-to-inputs.mdx
@@ -5,12 +5,13 @@ description: "Code nostalgia: Unleash your creativity and bring a vintage snake 
 category: web-design
 featuredImage: ../images/featured/InputsA.png
 featuredImageAlt: A retro handheld gaming device, positioned at the center of the screen. It has a simple landscape on its screen. The device is set against a bright blue background with white motion arcs resembling a rainbow and stylized stars. Blocky brown platforms on either side and a checkered floor complete the nostalgic video game scene.
-relatedReferences:
-  - p5/createButton
-  - p5.Element
-  - p5/keyPressed
-  - p5/keyCode
-  - p5/frameRate
+relatedContent:
+  references:
+    - en/p5/createbutton
+    - en/p5/p5element
+    - en/p5/keypressed
+    - en/p5/keycode
+    - en/p5/framerate
 authors:
   - Ruth Ikegah
   - Jules Kris

--- a/src/content/tutorials/en/setting-up-your-environment.mdx
+++ b/src/content/tutorials/en/setting-up-your-environment.mdx
@@ -5,10 +5,11 @@ description: A quick tutorial for setting up the p5.js Web Editor and VS Code to
 category: introduction
 featuredImage: ../images/featured/SetupA.jpg
 featuredImageAlt: An interactive sketch in the p5.js Web Editor draws circles on the canvas as the mouse pointer moves.
-relatedReferences:
-  - p5/setup
-  - p5/draw
-  - p5/background
+relatedContent:
+  references:
+    - en/p5/setup
+    - en/p5/draw
+    - en/p5/background
 authors:
   - Layla Quiñones
   - Jaleesa Trapp

--- a/src/content/tutorials/en/variables-and-change.mdx
+++ b/src/content/tutorials/en/variables-and-change.mdx
@@ -5,19 +5,20 @@ description: Learn about variables and how they can be used to create animated s
 category: introduction
 featuredImage: ../images/featured/VarThumb.jpg
 featuredImageAlt: A person juggles three balls as a car travels past behind them. A painting of a nighttime landscape with a tree, cloud and crescent moon hangs in the background.
-relatedExamples:
-  - 02_Animation_And_Variables/00_Drawing_Lines
-relatedReferences:
-  - p5/mouseX
-  - p5/mouseY
-  - p5/string
-  - p5/number
-  - p5/let
-  - p5/random
-  - p5/line
-  - p5/triangle
-  - p5/frameCount
-  - p5/frameRate
+relatedContent:
+  examples:
+    - en/02_animation_and_variables/00_drawing_lines/description
+  references:
+    - en/p5/mousex
+    - en/p5/mousey
+    - en/p5/string
+    - en/p5/number
+    - en/p5/let
+    - en/p5/random
+    - en/p5/line
+    - en/p5/triangle
+    - en/p5/framecount
+    - en/p5/framerate
 authors:
   - Layla Quiñones
   - Joanne Amarisa


### PR DESCRIPTION
Rather than addressing https://github.com/bocoup/p5.js-website/issues/148 directly, this just updates the tutorials to include the locale.