### PR TITLE
Styling updates for custom UI components

### DIFF
--- a/src/components/AnnotatedCode/index.astro
+++ b/src/components/AnnotatedCode/index.astro
@@ -70,20 +70,31 @@ for (const attr of preTag.attributes) {
   if (attr.name === 'style') continue
   preAttrs[attr.name] = attr.value;
 }
+preAttrs.class = (preAttrs.class || '') + ' code-box mr-md';
 const preStyle = preTag.getAttribute('style');
+const getPreStyle = (i: number) => {
+  let style = preStyle + ';';
+  if (i > 0) {
+    style += 'border-top-left-radius:0;border-top-right-radius:0;'
+  }
+  if (i < rows.length-1) {
+    style += 'border-bottom-left-radius:0;border-bottom-right-radius:0;'
+  }
+  return style;
+}
 const codeAttrs: Record<string, string> = {};
 for (const attr of codeTag.attributes) {
   codeAttrs[attr.name] = attr.value;
 }
 ---
-  <table class="h-1">
+  <table class="h-1 my-md">
     <tbody>
-      {rows.map(row => {
+      {rows.map((row, i) => {
         const lineNodes = lines.slice(row.startLine, row.endLine);
         return (
           <tr class="[&>*]:align-top [&>*]:m-0 [&>*:not(:first-child)]:py-2 [&>*:not(:first-child)]:max-w-xl">
-            <td class="align-top" style="height:100%; margin:0">
-            <pre {...preAttrs} style={`${preStyle};height:100%`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
+            <td class="align-top p-0" style="height:100%; margin:0">
+            <pre {...preAttrs} style={`${getPreStyle(i)};height:100%`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
             </td>
             {props.columns ? (
               <Fragment set:html={row.slot ? Astro.slots.render(row.slot) : undefined} />

--- a/src/components/AnnotatedLine/index.astro
+++ b/src/components/AnnotatedLine/index.astro
@@ -51,13 +51,13 @@ const lines = contents.split('\n').map((line, lineIdx) => {
 });
 ---
 
-<div class="code-box my-8">
+<div class="code-box my-8 [&_td]:p-0">
   {lines.map((line, i) => (
     <table style={i < lines.length - 1 ? 'margin-bottom: 0.2em' : undefined}>
       {line.some((chunk) => chunk.top) && (
         <tr>
           {line.map(({ top, color }) => (
-            <td class="text-center align-bottom max-w-0" style={top && color ? `background: ${color}` : undefined}>
+            <td class="text-[0.8em] text-center align-bottom max-w-0" style={top && color ? `background: ${color}` : undefined}>
               <Fragment set:html={top ? Astro.slots.render(top) : undefined} />
             </td>
           ))}
@@ -73,7 +73,7 @@ const lines = contents.split('\n').map((line, lineIdx) => {
       {line.some((chunk) => chunk.bottom) && (
         <tr>
           {line.map(({ bottom, color }) => (
-            <td class="text-center align-top max-w-0" style={bottom && color ? `background: ${color}` : undefined}>
+            <td class="text-[0.8em] text-center align-top max-w-0" style={bottom && color ? `background: ${color}` : undefined}>
               <Fragment set:html={bottom ? Astro.slots.render(bottom) : undefined} />
             </td>
           ))}

--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -60,6 +60,8 @@ export const CodeFrame = (props: CodeFrameProps) => {
   // animations only to start when they become visible.
   useLayoutEffect(() => {
     if (!containerRef.current) return;
+    const { IntersectionObserver } = window;
+    if (!IntersectionObserver) return;
 
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {

--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -1,3 +1,4 @@
+import { useRef, useLayoutEffect } from 'preact/hooks';
 import { p5VersionForEmbeds } from "@/src/globals/globals";
 
 /*
@@ -41,23 +42,56 @@ export interface CodeFrameProps {
   htmlBodyCode?: string;
   height?: number | string;
   width?: number | string;
+  base?: string;
 }
 
 /*
  * Component that uses an iframe to run code with the p5 library included.
  *
  */
-export const CodeFrame = (props: CodeFrameProps) => (
-  <iframe
-    srcDoc={wrapInMarkup({
-      js: props.jsCode,
-      css: props.cssCode,
-      htmlBody: props.htmlBodyCode,
-    })}
-    sandbox="allow-scripts allow-popups allow-modals allow-forms"
-    aria-label="Code Preview"
-    title="Code Preview"
-    height={props.height}
-    width={props.width}
-  />
-);
+export const CodeFrame = (props: CodeFrameProps) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // For performance, set the iframe to display:none when
+  // not visible on the page. This will stop the browser
+  // from running `draw` every frame, which helps performance
+  // on pages with multiple sketches, and causes sketch
+  // animations only to start when they become visible.
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (!iframeRef.current) return;
+        if (entry.isIntersecting) {
+          iframeRef.current.style.removeProperty('display');
+        } else {
+          iframeRef.current.style.display = 'none';
+        }
+      });
+    }, { rootMargin: '20px' });
+    observer.observe(containerRef.current)
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} style={{ width: props.width, height: props.height }}>
+      <iframe
+        ref={iframeRef}
+        srcDoc={wrapInMarkup({
+          js: props.jsCode,
+          css: props.cssCode,
+          htmlBody: props.htmlBodyCode,
+          base: props.base,
+        })}
+        sandbox="allow-scripts allow-popups allow-modals allow-forms"
+        aria-label="Code Preview"
+        title="Code Preview"
+        height={props.height}
+        width={props.width}
+      />
+    </div>
+  );
+}

--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "preact/hooks";
+import { useState, useEffect, useRef } from "preact/hooks";
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 
@@ -15,6 +15,7 @@ import { Icon } from "../Icon";
  *   previewable: boolean;
  *   previewHeight?: number;
  *   previewWidth?: number;
+ *   base?: string;
  * }
  */
 export const CodeEmbed = (props) => {
@@ -28,6 +29,17 @@ export const CodeEmbed = (props) => {
     initialCode.replace(/\u00A0/g, " "),
   );
 
+  const codeFrameRef = useRef(null);
+
+  const updateOrReRun = () => {
+    if (codeString === previewCodeString) {
+      setPreviewCodeString('');
+      requestAnimationFrame(() => setPreviewCodeString(codeString));
+    } else {
+      setPreviewCodeString(codeString);
+    }
+  }
+
   const [previewCodeString, setPreviewCodeString] = useState(codeString);
 
   useEffect(() => {
@@ -37,21 +49,21 @@ export const CodeEmbed = (props) => {
   if (!rendered) return <div className="code-placeholder" />;
 
   return (
-    <div className="mb-md flex w-full flex-col overflow-hidden lg:flex-row">
+    <div className="my-md flex w-full flex-col overflow-hidden lg:flex-row">
       {props.previewable ? (
         <div className="flex lg:flex-col">
           <CodeFrame
             jsCode={previewCodeString}
             width={props.previewWidth}
             height={props.previewHeight}
+            base={props.base}
+            frameRef={codeFrameRef}
           />
           {/* Looks more visually balanced with a slight leftward nudge */}
           <div className="gap-xs lg:flex">
             <CircleButton
               className="!bg-bg-gray-40 !p-sm lg:ml-[-2px]"
-              onClick={() => {
-                setPreviewCodeString(codeString);
-              }}
+              onClick={updateOrReRun}
             >
               <Icon kind="play" />
             </CircleButton>
@@ -66,7 +78,7 @@ export const CodeEmbed = (props) => {
           </div>
         </div>
       ) : null}
-      <div className="relative w-full md:w-[calc(100%-150px)]">
+      <div className="relative ml-md w-full md:w-[calc(100%-150px)]">
         <CodeMirror
           value={codeString}
           theme="light"

--- a/src/components/Columns/index.jsx
+++ b/src/components/Columns/index.jsx
@@ -1,12 +1,10 @@
 // TODO: layout vertically when the screen is small?
 export const Columns = (props) => (
-  <div class="flex flex-row items-start justify-start">
+  <div class="mt-md flex flex-col flex-wrap max-w-[100%] items-stretch justify-start lg:flex-row lg:items-start">
     {props.children}
   </div>
-)
+);
 
 export const Column = (props) => (
-  <div class="flex-1">
-    {props.children}
-  </div>
-)
+  <div class={`mb-md mr-md flex-1 max-w-[100%] ${props.class || ''} ${props.fixed ? 'grow-0' : 'min-w-[400px]'}`}>{props.children}</div>
+);

--- a/src/components/EditableSketch/index.astro
+++ b/src/components/EditableSketch/index.astro
@@ -3,14 +3,15 @@ import CodeEmbed from "../CodeEmbed";
 
 interface Props {
   code: string;
-  previewWidth?: number;
-  previewHeight?: number;
+  width?: number;
+  height?: number;
+  base?: string;
 }
 
 const { props } = Astro;
 
-let previewWidth = props.previewWidth;
-let previewHeight = props.previewHeight;
+let previewWidth = props.width;
+let previewHeight = props.height;
 const match = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:P2D|WEBGL)\s*)?\)/m.exec(props.code);
 if (match) {
   previewWidth = previewWidth || parseFloat(match[1]);
@@ -19,4 +20,4 @@ if (match) {
 
 ---
 
-<CodeEmbed client:load initialValue={props.code.trim()} previewWidth={previewWidth} previewHeight={previewHeight} previewable editable />
+<CodeEmbed client:load initialValue={props.code.trim()} previewWidth={previewWidth} previewHeight={previewHeight} base={props.base} previewable editable />

--- a/src/content/tutorials/en/conditionals-and-interactivity.mdx
+++ b/src/content/tutorials/en/conditionals-and-interactivity.mdx
@@ -21,6 +21,7 @@ authors:
 
 import { Callout } from "../../../components/Callout/";
 import { Columns, Column } from "../../../components/Columns";
+import AnnotatedLine from "../../../components/AnnotatedLine/index.astro";
 import Video from "../../../components/Video/index.astro"
 
 In this tutorial, you will learn new ways to add user interaction to your sketches, and control the order in which code runs. 
@@ -230,7 +231,14 @@ if (condition) {
 
 The code inside the parentheses after the keyword `if` can be a *Boolean value* or a *Boolean expression*. In the example below, a Boolean expression is used to check if the value in the `sunHeight` variable is less than the value in the `horizon` variable:
 
-![The syntax for an if statement with "sun height is less than horizon" in parentheses and labeled “Boolean expression.” The function that turns the background color of the canvas light blue is between curly braces labeled as the “code block.”](../images/introduction/annotated-if.jpg)
+<AnnotatedLine code={({ bottom }) => `
+if (${bottom('bool', 'sunHeight < horizon')}) {
+  ${bottom('block', 'background("lightblue");')}
+}
+`}>
+  <Fragment slot="bool">Boolean expression</Fragment>
+  <Fragment slot="block">Code block</Fragment>
+</AnnotatedLine>
 
 *Boolean expressions* are statements that result in a *Boolean* value. *Boolean* values can either be `true` or `false`*.* Unlike numbers or strings, there are only two Boolean values. *Boolean expressions* help check if conditions are `true` or `false`; therefore, they use symbols called *comparison operators*. *Comparison operators* are special symbols that compare two values (see the table below).
 

--- a/src/content/tutorials/en/intro-to-shaders.mdx
+++ b/src/content/tutorials/en/intro-to-shaders.mdx
@@ -390,15 +390,18 @@ ${end('attributes')}
 ${begin('uniforms')}
 // The transform of the object being drawn
 uniform mat4 uModelViewMatrix;
-// Transforms 3D coordinates to 2D screen coordinates
+// Transforms 3D coordinates to
+// 2D screen coordinates
 uniform mat4 uProjectionMatrix;
 ${end('uniforms')}
 ${begin('main')}
 void main() {
   // Apply the camera transform
-  vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
+  vec4 viewModelPosition =
+    uModelViewMatrix * vec4(aPosition, 1.0);
   // Tell WebGL where the vertex goes
-  gl_Position = uProjectionMatrix * viewModelPosition;  
+  gl_Position =
+    uProjectionMatrix * viewModelPosition;  
 }
 ${end('main')}`}>
   <Fragment slot="precision">

--- a/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
+++ b/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
@@ -41,7 +41,7 @@ Framebuffers can also contain more information than a typical image or canvas. Y
 
 <tr>
 
-<td>
+<td colspan="3">
 
 ![Three renderings of a line of spheres going off into the distance. The first shows them in focus and in color. The second shows them monochrome, getting more white as they go into the distance. The final one is in color, with spheres getting more blurred as they go into the distance.](../images/webgl/fbo-channels.png)
 
@@ -51,23 +51,23 @@ Framebuffers can also contain more information than a typical image or canvas. Y
 
 <tr>
 
-<td>
+<th width="300">
 
 Framebuffer color
 
-</td>
+</th>
 
-<td>
+<th width="300">
 
 Framebuffer depth
 
-</td>
+</th>
 
-<td>
+<th width="300">
 
 Final image with focal blur using color + depth
 
-</td>
+</th>
 
 </tr>
 
@@ -152,7 +152,7 @@ function draw() {
 }
 ```
 </Column>
-<Column>
+<Column fixed>
 #### Result
 
 <SketchEmbed width="200" height="200" code={`

--- a/src/content/tutorials/en/lights-camera-materials.mdx
+++ b/src/content/tutorials/en/lights-camera-materials.mdx
@@ -256,10 +256,10 @@ function draw() {
 
 More custom materials can be achieved by using the `texture()` function. This allows you to map an image to the surface of a geometry. These textures can be imported from an image and even generated within code using shaders. To map a texture to your geometry, use `loadImage()` within `preload()`, then call `texture()` before drawing your shape.
 
-<EditableSketch code={`
+<EditableSketch base="/images/tutorials/" code={`
 let myTexture;
 function preload() {
-  myTexture = loadImage('/images/tutorials/simpleTexture.png');
+  myTexture = loadImage('simpleTexture.png');
 }
 function setup() {
   createCanvas(200, 200, WEBGL);
@@ -283,10 +283,10 @@ When you create custom geometry you can specify a texture coordinate for each ve
 
 The texture coordinates of a vertex can stay the same while its 3D position changes. You can use this to distort and animate images. In the example below, changing vertex positions while keeping texture coordinates the same is used to wiggle a drawing. Click and hold on the canvas to see the edges of the grid of vertices being drawn.
 
-<EditableSketch code={`
+<EditableSketch base="/images/tutorials/" code={`
 let img;
 function preload() {
-  img = loadImage('/images/tutorials/wiggly-guy.png');
+  img = loadImage('wiggly-guy.png');
 }
 function setup() {
   createCanvas(200, 200, WEBGL);

--- a/src/content/tutorials/en/optimizing-webgl-sketches.mdx
+++ b/src/content/tutorials/en/optimizing-webgl-sketches.mdx
@@ -71,7 +71,9 @@ function draw() {
   if (frameRateSamples.length > numSamples) {
     frameRateSum -= frameRateSamples.shift();
   }
-  frameRateP.html(round(frameRateSum / frameRateSamples.length));
+  frameRateP.html(
+    round(frameRateSum / frameRateSamples.length)
+  );
   // Put the rest of your sketch here
 }
 ```
@@ -99,7 +101,10 @@ let layer;
 function setup() {
   createCanvas(200, 200, WEBGL);
   layer = createGraphics(200, 200);
-  describe('a rotating red cube with yellow dots on each face');
+  describe(
+    'a rotating red cube with yellow ' +
+    'dots on each face'
+  );
 }
 function draw() {
   let t = millis() * 0.001;
@@ -132,7 +137,10 @@ let layer;
 function setup() {
   createCanvas(200, 200, WEBGL);
   layer = createFramebuffer();
-  describe('a rotating red cube with yellow dots on each face');
+  describe(
+    'a rotating red cube with yellow ' +
+    'dots on each face'
+  );
 }
 function draw() {
   let t = millis() * 0.001;
@@ -159,7 +167,7 @@ function draw() {
 }
 ```
 </Column>
-<Column>
+<Column fixed>
 <SketchEmbed width={200} height={200} code={`
 let layer;
 function setup() {
@@ -221,7 +229,10 @@ function setup() {
   layer.textSize(50);
   layer.text('Hello!', width/2, height/2);
 
-  describe('a rotating red cube with the word "Hello!" in yellow on each face');
+  describe(
+    'a rotating red cube with the word ' +
+    '"Hello!" in yellow on each face'
+  );
 }
 function draw() {
   let t = millis() * 0.001;
@@ -257,7 +268,10 @@ function setup() {
   // We no longer need the original
   layer.remove();
 
-  describe('a rotating red cube with the word "Hello!" in yellow on each face');
+  describe(
+    'a rotating red cube with the word ' +
+    '"Hello!" in yellow on each face'
+  );
 }
 function draw() {
   let t = millis() * 0.001;
@@ -272,7 +286,7 @@ function draw() {
 }
 ```
 </Column>
-<Column>
+<Column fixed>
 <SketchEmbed width={200} height={200} code={`
 let layerImg;
 function setup() {
@@ -291,7 +305,10 @@ function setup() {
   // We no longer need the original
   layer.remove();
 
-  describe('a rotating red cube with the word "Hello!" in yellow on each face');
+  describe(
+    'a rotating red cube with the word ' +
+    '"Hello!" in yellow on each face'
+  );
 }
 function draw() {
   let t = millis() * 0.001;
@@ -375,7 +392,7 @@ function draw() {
 }
 ```
 </Column>
-<Column>
+<Column fixed>
 <SketchEmbed width={200} height={200} code={`
 let shape;
 function setup() {
@@ -498,7 +515,7 @@ function draw() {
 }
 ```
 </Column>
-<Column>
+<Column fixed>
 <SketchEmbed width={200} height={200} code={`
 function setup() {
   createCanvas(200, 200, WEBGL);
@@ -580,7 +597,7 @@ function setup() {
 
 When you aren't drawing premade shapes with `model()`, things generally run faster when fewer triangles and edges are involved. One way to tune how detailed your shapes are is with `curveDetail()`: the larger the value you give, the more edges and triangles are used when breaking down curves. Try using a level of detail smaller than the default value of 20.
 
-<EditableSketch width={200} height={300} code={`
+<EditableSketch width={200} height={250} code={`
 let detailSlider;
 function setup() {
   createCanvas(200, 200, WEBGL);

--- a/src/content/tutorials/en/speak-with-your-hands.mdx
+++ b/src/content/tutorials/en/speak-with-your-hands.mdx
@@ -109,7 +109,7 @@ function drawKeypoints() {
 ```
 
 </Column>
-<Column>
+<Column class="basis-64 grow-0">
 
 ![The palm of a hand with 4 fingers in green color that identify each finger, and 5 green points identifying the thumb and the bottom of the palm.](../images/advanced/handpose_image.jpg)
 
@@ -220,7 +220,7 @@ function drawKeypoints() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![The palm of a hand with 4 fingers in green color that identify each finger, and 5 green points identifying the thumb and the bottom of the palm.](../images/advanced/handpose_image.jpg)
 
@@ -319,7 +319,7 @@ function drawKeypoints() {
 ```
 
 </Column>
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A hand with the tip of each finger and thumb identified with a different coloured dot.](../images/advanced/ml5-hand-multicolor.png)
 
@@ -439,7 +439,7 @@ function drawKeypoints() {
 ```
 
 </Column>
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A hand where the tip of each finger and thumb has a joker's hat on it](../images/advanced/ml5-hand-hats.png)
 
@@ -506,7 +506,7 @@ function drawKeypoints() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A video feed of a hand up in the air with green dots on each finger](../images/advanced/ml5-pose-webcam.gif)
 
@@ -613,7 +613,7 @@ function drawKeypoints() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A hand moving around the screen where the tip of each finger and thumb has a joker's hat on it and the hats move with the hand.](../images/advanced/ml5-webcam-hats.gif)
 
@@ -705,7 +705,7 @@ function drawObject() {
 ```
 
 </Column>
-<Column>
+<Column class="basis-64 grow-0">
 
 ![Video of fingers (one or many) moving around the screen, with a white dot on the tip of the index finger only](../images/advanced/ml5js-webcam-ballcontrol.gif)
 
@@ -758,7 +758,7 @@ function drawObject() {
 ```
 
 </Column>
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A webcam feed of a hand in the air with three white circles on the three central fingers of the hand](../images/advanced/ml5-webcam-multiple.gif)
 
@@ -818,7 +818,7 @@ function drawObject() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A finger pointing to the right or left with a gray rectangle covering half the screen where the finger is pointing ](../images/advanced/mljs-move-object.gif)
 
@@ -903,7 +903,7 @@ function drawObject() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A gray box in the middle of the screen and a small gray dot moving near the box. The box turns yellow when the dot is within the box.](../images/advanced/mljs-handpose-colour.gif)
 
@@ -1033,11 +1033,11 @@ function drawObject() {
 
 </Column>
 
-<Column>
+<Column class="basis-64 grow-0">
 
 ![A flower made with circles which come together as one big circle and open up as many circles](../images/advanced/ml5js-flowerblooming.gif)
 
-CAPTION TEXT: Sketch by [Akif Kazi](https://www.instagram.com/designer_akifkazi), Student at KJ Somaiya University, Mumbai.
+Sketch by [Akif Kazi](https://www.instagram.com/designer_akifkazi), Student at KJ Somaiya University, Mumbai.
 
 [Live](https://editor.p5js.org/vyasakanksha/sketches/tqvxO53fn)
 

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -152,9 +152,15 @@ a {
 
 code {
   @extend .text-body-mono;
+  font-size: inherit;
   background-color: var(--bg-gray-80);
   border-radius: 20px;
   padding: 0 var(--spacing-xxs);
+}
+
+.astro-code {
+  margin-top: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
 }
 
 .astro-code code, .code-box code {
@@ -166,6 +172,9 @@ code {
 .astro-code, .code-box {
   background-color: var(--bg-gray-40);
   padding: var(--spacing-sm);
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: break-spaces;
 
   border-radius: 20px;
 }
@@ -246,4 +255,8 @@ code {
   @media (min-width: $breakpoint-desktop) {
     grid-template-columns: repeat(12, minmax(0, 1fr));
   }
+}
+
+td, th {
+  padding: var(--spacing-xs);
 }


### PR DESCRIPTION
- Makes the play button on editable sketches rerun the sketch if no content has changed
- Makes editable sketch iframes `display:none` when not on screen (for performance and so animations aren't done by the time you scroll to them)
- Makes `Columns` handle changes in viewport sizes better (turns vertical at a breakpoint)
- Removes small white borders between rows in `AnnotatedCode`
- Updates some sketch content to be organized a bit more nicely