### PR TITLE
Specify order for tutorials within categories

### DIFF
--- a/src/content/tutorials/config.ts
+++ b/src/content/tutorials/config.ts
@@ -1,7 +1,7 @@
 import { z, defineCollection } from "astro:content";
 import { relatedContent } from "../shared";
 
-const categories = [
+export const categories = [
   "introduction",
   "drawing",
   "web-design",
@@ -9,6 +9,15 @@ const categories = [
   "webgl",
   "advanced",
 ] as const;
+
+export const categoryNames: { [key in (typeof categories)[number]]: string } = {
+  introduction: 'Introduction to p5.js',
+  drawing: 'Drawing',
+  'web-design': 'Web Design',
+  accessibility: 'Accessibility',
+  webgl: 'WebGL',
+  'advanced': 'Advanced Topics',
+};
 
 /**
  * Content collection for the Sketches showcase section of the site.
@@ -25,6 +34,7 @@ export const tutorialsCollection = defineCollection({
       authorsNote: z.string().optional(),
       description: z.string().optional(),
       category: z.enum(categories),
+      categoryIndex: z.number().optional(),
       // Image to use as a thumbnail for the tutorial
       featuredImage: image().optional(),
       featuredImageAlt: z.string().optional(),

--- a/src/content/tutorials/en/color-gradients.mdx
+++ b/src/content/tutorials/en/color-gradients.mdx
@@ -3,6 +3,7 @@ slug: color-gradients
 title: "Color Gradients"
 description: Use radial gradients, linear gradients, and blend modes to create lens flare stickers & colorful filters on top of a webcam selfie.
 category: drawing
+categoryIndex: 0
 featuredImage: ../images/featured/ColorGradientsA.png
 featuredImageAlt: A webcam snapshot of a white person with short dark curly hair wearing pink heart shaped glasses posing for a picture. There is a red to yellow linear gradient filter on top of the photo. Colorful circles are scattered on top of the image with a color gradient overlay. The circles have randomized radial color gradients inside them to mimic a camera's lens flare. Some color gradients are pink to purple, cyan to green, or yellow to orange.
 relatedContent:

--- a/src/content/tutorials/en/conditionals-and-interactivity.mdx
+++ b/src/content/tutorials/en/conditionals-and-interactivity.mdx
@@ -3,6 +3,7 @@ slug: conditionals-and-interactivity
 title: "Conditionals and Interactivity"
 description: A tutorial on how to use conditional statements and make interactive sketches.
 category: introduction
+categoryIndex: 3
 featuredImage: ../images/featured/ConditionalsA.png
 featuredImageAlt: A preview of the sunrise animation created in the Conditionals and Interactivity tutorial.
 relatedContent:

--- a/src/content/tutorials/en/coordinates-and-transformations.mdx
+++ b/src/content/tutorials/en/coordinates-and-transformations.mdx
@@ -3,6 +3,7 @@ slug: coordinates-and-transformations
 title: "Coordinates and Transformations"
 description: An overview of the different ways you can position objects in WebGL mode.
 category: webgl
+categoryIndex: 0
 featuredImage: ../images/featured/coordinates-and-transformations.jpg
 featuredImageAlt: A cube on top of a grid with colored lines showing its movement in 3D space.
 relatedContent:

--- a/src/content/tutorials/en/custom-geometry.mdx
+++ b/src/content/tutorials/en/custom-geometry.mdx
@@ -3,6 +3,7 @@ slug: custom-geometry
 title: "Creating Custom Geometry in WebGL"
 description: A guide to the different ways you can create your own 3D shapes.
 category: webgl
+categoryIndex: 1
 featuredImage: ../images/featured/custom-geometry.png
 featuredImageAlt: A bunch of red ladybugs on a green background
 relatedContent:

--- a/src/content/tutorials/en/custom-shapes-and-smooth-curves.mdx
+++ b/src/content/tutorials/en/custom-shapes-and-smooth-curves.mdx
@@ -3,6 +3,7 @@ slug: custom-shapes-and-smooth-curves
 title: "Custom Shapes and Smooth Curves"
 description: Use vertex(), bezierVertex(), beginShape() and endShape() to create angular and curved sparkle stickers to place on top of your webcam selfie.
 category: drawing
+categoryIndex: 1
 featuredImage: ../images/featured/CustomShapesSmoothCurvesA.png
 featuredImageAlt: A white person with short, dark curly hair wears pink heart-shaped glasses and a dark sleeveless shirt. He places his hand on his cheek and looks diagonally to the left, smiling softly. A vertical linear blue to pink gradient is overlaid. On top of that, we see a mixture of angular and curved white 4-pointed sparkles of varying sizes, with an angular sparkle over the left lens of his glasses, and a curved sparkle over the right lens. We see pink and blue radial gradient circles layered on top, creating a lens flare effect.
 relatedContent:

--- a/src/content/tutorials/en/data-structure-garden.mdx
+++ b/src/content/tutorials/en/data-structure-garden.mdx
@@ -3,6 +3,7 @@ slug: data-structure-garden
 title: "Data Structure Garden"
 description: A tutorial on how to use JavaScript objects and arrays.
 category: introduction
+categoryIndex: 6
 featuredImage: ../images/featured/DataStructuresGardenA.png
 featuredImageAlt: A preview of the interactive flower garden with flowers appearing on a light blue canvas as a user clicks with their mouse pointer.
 relatedContent:

--- a/src/content/tutorials/en/field-guide-to-debugging.mdx
+++ b/src/content/tutorials/en/field-guide-to-debugging.mdx
@@ -3,6 +3,7 @@ slug: field-guide-to-debugging
 title: "Field Guide to Debugging"
 description: Learn some healthy habits and best practices for  locating bugs in your program, and finding ways to overcome them.
 category: advanced
+categoryIndex: 0
 featuredImage: ../images/featured/FieldGuide.png
 featuredImageAlt: "The title is “A Field Guide to Debugging!” and it features a black-and-white cartoon illustrations of insects, a mouse and a computer laptop in deep thought."
 relatedContent:

--- a/src/content/tutorials/en/get-started.mdx
+++ b/src/content/tutorials/en/get-started.mdx
@@ -3,6 +3,7 @@ slug: get-started
 title: Get Started
 description: A tutorial that introduces basic p5.js functions and guides you through the steps to create an interactive landscape.
 category: introduction
+categoryIndex: 1
 featuredImage: ../images/featured/GetStartedA.png
 featuredImageAlt: A preview of the interactive landscape project showing a ladybug and flower emoji in front of a simple landscape background.
 relatedContent:

--- a/src/content/tutorials/en/getting-started-with-nodejs.mdx
+++ b/src/content/tutorials/en/getting-started-with-nodejs.mdx
@@ -3,6 +3,7 @@ slug: getting-started-with-nodejs
 title: "Getting Started with Node.js"
 description: Learn about HTTP requests and how to use Node.js in your p5.js projects to create dynamic projects that save and retrieve files.
 category: advanced
+categoryIndex: 3
 featuredImage: ../images/featured/node.png
 featuredImageAlt: A p5.js logo with musical notes above it has arrows labeled with HTTP methods pointing to a cloud labeled “Internet”. Above the cloud is an icon that reads “http\://”. Arrows point from the cloud to a pink cube labeled “Web Server” with the Node.js logo above it.
 relatedContent:

--- a/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
+++ b/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
@@ -3,6 +3,7 @@ slug: how-to-optimize-your-sketches
 title: How to Optimize Your Sketches
 description: An advanced tutorial on how to optimize code in your sketches to run more efficiently.
 category: advanced
+categoryIndex: 1
 featuredImage: ../images/featured/OptimizeA.png
 featuredImageAlt: The bouncing particles animation used in this tutorial displays orange circles bouncing around a dark canvas.
 relatedContent:

--- a/src/content/tutorials/en/intro-to-shaders.mdx
+++ b/src/content/tutorials/en/intro-to-shaders.mdx
@@ -3,6 +3,7 @@ slug: intro-to-shaders
 title: "Introduction to Shaders"
 description: An introduction to the different ways you can create interesting visual effects with your computer's GPU.
 category: webgl
+categoryIndex: 3
 featuredImage: ../images/featured/intro-to-shaders.jpg
 featuredImageAlt: A warped, wavy city street
 relatedContent:

--- a/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
+++ b/src/content/tutorials/en/layered-rendering-with-framebuffers.mdx
@@ -3,6 +3,7 @@ slug: layered-rendering-with-framebuffers
 title: "Layered Rendering with Framebuffers"
 description: Framebuffers are the fastest way to create a scene out of multiple layers in WebGL. Explore how to use them, and the unique 3D information they provide.
 category: webgl
+categoryIndex: 4
 featuredImage: ../images/featured/layered-rendering-with-framebuffers.png
 featuredImageAlt: A line of spheres receding into fog as they go off into the distance
 relatedContent:

--- a/src/content/tutorials/en/lights-camera-materials.mdx
+++ b/src/content/tutorials/en/lights-camera-materials.mdx
@@ -3,6 +3,7 @@ slug: lights-camera-materials
 title: "Lights, Camera, Materials"
 description: TODO
 category: webgl
+categoryIndex: 2
 featuredImage: ../images/featured/lights-camera-material.jpg
 featuredImageAlt: A sphere in front of some walls and a floor, lit by a red, green, and blue light.
 relatedcontent:

--- a/src/content/tutorials/en/optimizing-webgl-sketches.mdx
+++ b/src/content/tutorials/en/optimizing-webgl-sketches.mdx
@@ -3,6 +3,7 @@ slug: optimizing-webgl-sketches
 title: "Optimizing WebGL Sketches"
 description: Tips to help make your sketches run as smoothly as possible on as many devices as possible.
 category: webgl
+categoryIndex: 5
 featuredImage: ../images/featured/optimizing-webgl-sketches.png
 featuredImageAlt: A screenshot of the profiler in the developer tools of Google Chrome
 relatedContent:

--- a/src/content/tutorials/en/organizing-code-with-functions.mdx
+++ b/src/content/tutorials/en/organizing-code-with-functions.mdx
@@ -3,6 +3,7 @@ slug: organizing-code-with-functions
 title: Organizing Code with Functions
 description: A tutorial on how to create and use functions to help you organize your code.
 category: introduction
+categoryIndex: 4
 featuredImage: ../images/featured/FunctionsA.png
 featuredImageAlt: A canvas displaying a snapshot of the sunrise animation from the Conditionals and Interactivity tutorial. The snapshot includes a sun, and trees and mountains in the landscape.
 relatedContent:

--- a/src/content/tutorials/en/repeating-with-loops.mdx
+++ b/src/content/tutorials/en/repeating-with-loops.mdx
@@ -3,6 +3,7 @@ slug: repeating-with-loops
 title: "Repeating with Loops"
 description: "Create a crawling caterpillar race using loops and arrays!"
 category: introduction
+categoryIndex: 5
 featuredImage: ../images/featured/loops.png
 featuredImageAlt: Three pink caterpillars with googly eyes on the starting line wait for the race with the text “Click to start”.
 relatedContent:

--- a/src/content/tutorials/en/setting-up-your-environment.mdx
+++ b/src/content/tutorials/en/setting-up-your-environment.mdx
@@ -3,6 +3,7 @@ slug: setting-up-your-environment
 title: "Setting Up Your Environment"
 description: A quick tutorial for setting up the p5.js Web Editor and VS Code to write and save p5.js projects.
 category: introduction
+categoryIndex: 0
 featuredImage: ../images/featured/SetupA.jpg
 featuredImageAlt: An interactive sketch in the p5.js Web Editor draws circles on the canvas as the mouse pointer moves.
 relatedContent:

--- a/src/content/tutorials/en/speak-with-your-hands.mdx
+++ b/src/content/tutorials/en/speak-with-your-hands.mdx
@@ -2,7 +2,8 @@
 slug: speak-with-your-hands
 title: "Abracadabra: Speak With Your Hands in p5.js and ml5.js"
 description: Control sketches with your hands using ml5.js
-category: webgl
+category: advanced
+categoryIndex: 2
 featuredImage: ../images/featured/handflower.png
 featuredImageAlt: The palm of a hand with 4 points in green color that identify each finger, and 5 green points identifying the thumb and  bottom of the palm.
 authors:

--- a/src/content/tutorials/en/variables-and-change.mdx
+++ b/src/content/tutorials/en/variables-and-change.mdx
@@ -3,6 +3,7 @@ slug: variables-and-change
 title: "Variables and Change"
 description: Learn about variables and how they can be used to create animated sketches!
 category: introduction
+categoryIndex: 2
 featuredImage: ../images/featured/VarThumb.jpg
 featuredImageAlt: A person juggles three balls as a car travels past behind them. A painting of a nighttime landscape with a tree, cloud and crescent moon hangs in the background.
 relatedContent:

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -2,31 +2,46 @@
 import { type CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 import { Image } from "astro:assets";
+import { categories, categoryNames } from '../content/tutorials/config';
 
 type TutorialEntry = CollectionEntry<"tutorials">;
 
 const { entries } = Astro.props;
+
+const sections = categories.map((slug) => {
+  const name = categoryNames[slug];
+  const sectionEntries = entries
+    .filter((e) => e.data.category === slug)
+    .sort((a, b) => (a.data.categoryIndex ?? 1000) - (b.data.categoryIndex ?? 1000));
+
+  return { slug, name, sectionEntries };
+})
 ---
 
 <BaseLayout title="Tutorials">
-  <ul>
-    {
-      entries.map((entry: TutorialEntry) => (
-        <li>
-          <a href={`/tutorials/${entry.slug}`}>
-            {" "}
-            {entry.data.featuredImageAlt && entry.data.featuredImage && (
-              <Image
-                src={entry.data.featuredImage}
-                alt={entry.data.featuredImageAlt}
-                width={200}
-                height={200}
-              />
-            )}
-            {entry.data.title}
-          </a>
-        </li>
-      ))
-    }
-  </ul>
+  {sections.map(({ slug, name, sectionEntries }) => (
+    <>
+      <h3 id={slug}>{name}</h3>
+      <ul>
+        {
+          sectionEntries.map((entry: TutorialEntry) => (
+            <li>
+              <a href={`/tutorials/${entry.slug}`}>
+                {" "}
+                {entry.data.featuredImageAlt && entry.data.featuredImage && (
+                  <Image
+                    src={entry.data.featuredImage}
+                    alt={entry.data.featuredImageAlt}
+                    width={200}
+                    height={200}
+                  />
+                )}
+                {entry.data.title}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </>
+  ))}
 </BaseLayout>

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -11,8 +11,10 @@ const { entries } = Astro.props;
 const sections = categories.map((slug) => {
   const name = categoryNames[slug];
   const sectionEntries = entries
-    .filter((e) => e.data.category === slug)
-    .sort((a, b) => (a.data.categoryIndex ?? 1000) - (b.data.categoryIndex ?? 1000));
+    .filter((e: TutorialEntry) => e.data.category === slug)
+    .sort((a: TutorialEntry, b: TutorialEntry) =>
+      (a.data.categoryIndex ?? 1000) - (b.data.categoryIndex ?? 1000)
+    );
 
   return { slug, name, sectionEntries };
 })


### PR DESCRIPTION
There's an order to the tutorials in some categories (it's optional overall, but some tutorials build off of previous ones.) I've added an optional `categoryIndex` to the config, set it on tutorials where the order matters, and have updated the layout to list them in that order.

Let me know if this method of specifying the order makes sense!