### PR TITLE
Pagination

### DIFF
--- a/src/components/CircleButton/index.tsx
+++ b/src/components/CircleButton/index.tsx
@@ -5,21 +5,38 @@ type CircleButtonProps = {
   ariaLabel: string;
   children: Element | JSX.Element;
   className?: string;
+  href?: string;
 };
 
 export const CircleButton = ({
   onClick,
   ariaLabel,
   children,
+  href,
   className = "",
-}: CircleButtonProps) => (
-  <button
-    onClick={onClick}
-    aria-label={ariaLabel}
-    className={`rounded-full bg-bg-white p-xs hover:border-type-white hover:!bg-bg-black hover:text-type-white hover:outline ${className}`}
-  >
-    {children}
-  </button>
-);
+}: CircleButtonProps) => {
+  const sharedClassName = `rounded-full p-xs hover:border-type-white hover:!bg-bg-black hover:text-type-white hover:outline ${className}`;
+  if (href) {
+    return (
+      <a
+        onClick={onClick}
+        aria-label={ariaLabel}
+        href={href}
+        className={sharedClassName}
+      >
+        {children}
+      </a>
+    );
+  }
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={sharedClassName}
+    >
+      {children}
+    </button>
+  );
+};
 
 export default CircleButton;

--- a/src/components/PaginationNav/index.astro
+++ b/src/components/PaginationNav/index.astro
@@ -23,7 +23,7 @@ const numPages = getPaginationMax(itemsPerPage, maxNumItems);
           <CircleButton
             ariaLabel={`Go to page ${i + 1}`}
             href={`${sectionUrlPrefix}/page/${i + 1}`}
-            className={`${currentPage === i + 1 && "text-sidebar-bg-color bg-sidebar-type-color"} text-3xl border border-sidebar-type-color !w-[50px] !h-[50px] flex items-center justify-center`}
+            className={`${currentPage === i + 1 && "text-sidebar-bg-color bg-sidebar-type-color"} text-2xl md:text-3xl border border-sidebar-type-color w-[40px] h-[40px] md:w-[50px] md:h-[50px] flex items-center justify-center`}
           >
             <span>{i + 1}</span>
           </CircleButton>

--- a/src/components/PaginationNav/index.astro
+++ b/src/components/PaginationNav/index.astro
@@ -15,18 +15,20 @@ const { maxNumItems, itemsPerPage, sectionUrlPrefix, currentPage } =
 const numPages = getPaginationMax(itemsPerPage, maxNumItems);
 ---
 
-<ul class="flex gap-xs my-sm">
-  {
-    Array.from({ length: numPages }).map((_, i) => (
-      <li>
-        <CircleButton
-          ariaLabel={`Go to page ${i + 1}`}
-          href={`${sectionUrlPrefix}/page/${i + 1}`}
-          className={`${currentPage === i + 1 && "text-sidebar-bg-color bg-sidebar-type-color"} text-3xl border border-sidebar-type-color !w-[50px] !h-[50px] flex items-center justify-center`}
-        >
-          <span>{i + 1}</span>
-        </CircleButton>
-      </li>
-    ))
-  }
-</ul>
+{
+  numPages > 1 && (
+    <ul class="flex gap-xs my-sm">
+      {Array.from({ length: numPages }).map((_, i) => (
+        <li>
+          <CircleButton
+            ariaLabel={`Go to page ${i + 1}`}
+            href={`${sectionUrlPrefix}/page/${i + 1}`}
+            className={`${currentPage === i + 1 && "text-sidebar-bg-color bg-sidebar-type-color"} text-3xl border border-sidebar-type-color !w-[50px] !h-[50px] flex items-center justify-center`}
+          >
+            <span>{i + 1}</span>
+          </CircleButton>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/PaginationNav/index.astro
+++ b/src/components/PaginationNav/index.astro
@@ -1,0 +1,32 @@
+---
+import { getPaginationMax } from "@/src/pages/_utils";
+import CircleButton from "../CircleButton";
+
+interface Props {
+  maxNumItems: number;
+  itemsPerPage: number;
+  sectionUrlPrefix: string;
+  currentPage: number;
+}
+
+const { maxNumItems, itemsPerPage, sectionUrlPrefix, currentPage } =
+  Astro.props;
+
+const numPages = getPaginationMax(itemsPerPage, maxNumItems);
+---
+
+<ul class="flex gap-xs my-sm">
+  {
+    Array.from({ length: numPages }).map((_, i) => (
+      <li>
+        <CircleButton
+          ariaLabel={`Go to page ${i + 1}`}
+          href={`${sectionUrlPrefix}/page/${i + 1}`}
+          className={`${currentPage === i + 1 && "text-sidebar-bg-color bg-sidebar-type-color"} text-3xl border border-sidebar-type-color !w-[50px] !h-[50px] flex items-center justify-center`}
+        >
+          <span>{i + 1}</span>
+        </CircleButton>
+      </li>
+    ))
+  }
+</ul>

--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -23,4 +23,4 @@ export const contentTypes = [
 export const p5VersionForEmbeds = "1.9.1" as const;
 
 export const sketchesPerPage = 12 as const;
-export const eventsPerPage = 3 as const;
+export const eventsPerPage = 12 as const;

--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -23,4 +23,4 @@ export const contentTypes = [
 export const p5VersionForEmbeds = "1.9.1" as const;
 
 export const sketchesPerPage = 12 as const;
-export const eventsPerPage = 12 as const;
+export const eventsPerPage = 3 as const;

--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -21,3 +21,6 @@ export const contentTypes = [
 ] as const;
 
 export const p5VersionForEmbeds = "1.9.1" as const;
+
+export const sketchesPerPage = 12 as const;
+export const eventsPerPage = 12 as const;

--- a/src/layouts/EventsLayout.astro
+++ b/src/layouts/EventsLayout.astro
@@ -3,16 +3,26 @@ import type { CollectionEntry } from "astro:content";
 
 import BaseLayout from "./BaseLayout.astro";
 import GridItemEvent from "@components/GridItem/Event.astro";
+import PaginationNav from "@components/PaginationNav/index.astro";
+import { eventsPerPage } from "../globals/globals";
 
 interface Props {
   entries: CollectionEntry<"past-events">[];
+  totalNumEvents: number;
+  currentPage: number;
 }
 
-const { entries } = Astro.props;
+const { entries, totalNumEvents, currentPage } = Astro.props;
 ---
 
 <BaseLayout title="Events" variant="root">
   <ul class="grid grid-cols-2 gap-y-xl gap-x-md md:grid-cols-4">
     {entries.map((entry) => <GridItemEvent item={entry} />)}
   </ul>
+  <PaginationNav
+    maxNumItems={totalNumEvents}
+    itemsPerPage={eventsPerPage}
+    currentPage={currentPage}
+    sectionUrlPrefix="/past-events"
+  />
 </BaseLayout>

--- a/src/layouts/SketchesLayout.astro
+++ b/src/layouts/SketchesLayout.astro
@@ -1,17 +1,27 @@
 ---
 import { type OpenProcessingCurationResponse } from "../api/OpenProcessing";
+import { sketchesPerPage } from "../globals/globals";
 import BaseLayout from "./BaseLayout.astro";
 import GridItemSketch from "@components/GridItem/Sketch.astro";
+import PaginationNav from "@components/PaginationNav/index.astro";
 
 interface Props {
   entries: OpenProcessingCurationResponse;
+  totalNumSketches: number;
+  currentPage: number;
 }
 
-const { entries } = Astro.props;
+const { entries, totalNumSketches, currentPage } = Astro.props;
 ---
 
 <BaseLayout title="Sketches" variant="root">
   <ul class="grid grid-cols-2 gap-y-xl gap-x-md md:grid-cols-4">
     {entries.map((entry) => <GridItemSketch item={entry} />)}
   </ul>
+  <PaginationNav
+    maxNumItems={totalNumSketches}
+    itemsPerPage={sketchesPerPage}
+    sectionUrlPrefix="/sketches"
+    currentPage={currentPage}
+  />
 </BaseLayout>

--- a/src/pages/[locale]/past-events/index.astro
+++ b/src/pages/[locale]/past-events/index.astro
@@ -1,4 +1,5 @@
 ---
+import { eventsPerPage } from "@/src/globals/globals";
 import { nonDefaultSupportedLocales } from "@i18n/const";
 import EventsLayout from "@layouts/EventsLayout.astro";
 import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
@@ -9,14 +10,22 @@ export async function getStaticPaths() {
       locale,
     },
     props: {
-      entries: await getCollectionInLocaleWithFallbacks("past-events", locale),
+      allEvents: await getCollectionInLocaleWithFallbacks(
+        "past-events",
+        locale
+      ),
     },
   }));
 
   return await Promise.all(pages);
 }
 
-const { entries } = Astro.props;
+const { allEvents } = Astro.props;
+const events = allEvents.slice(0, eventsPerPage);
 ---
 
-<EventsLayout entries={entries} />
+<EventsLayout
+  entries={events}
+  totalNumEvents={allEvents.length}
+  currentPage={1}
+/>

--- a/src/pages/[locale]/past-events/page/[...pageNumber].astro
+++ b/src/pages/[locale]/past-events/page/[...pageNumber].astro
@@ -1,0 +1,42 @@
+---
+import {
+  getCollectionInLocaleWithFallbacks,
+  getPaginationMax,
+} from "@pages/_utils";
+import { eventsPerPage } from "@/src/globals/globals";
+import { nonDefaultSupportedLocales } from "@/src/i18n/const";
+import EventsLayout from "@/src/layouts/EventsLayout.astro";
+
+export async function getStaticPaths() {
+  const paths = [];
+  for (const locale of nonDefaultSupportedLocales) {
+    const events = await getCollectionInLocaleWithFallbacks(
+      "past-events",
+      locale
+    );
+    const paginationMax = getPaginationMax(eventsPerPage, events.length);
+    for (let i = 1; i <= paginationMax; i++) {
+      paths.push({
+        params: { locale, pageNumber: i.toString() },
+        props: {
+          allEvents: events,
+          pageNumber: i,
+        },
+      });
+    }
+  }
+  console.log("PATHS", paths);
+  return paths;
+}
+const { allEvents, pageNumber } = Astro.props;
+const events = allEvents.slice(
+  (pageNumber - 1) * eventsPerPage,
+  pageNumber * eventsPerPage
+);
+---
+
+<EventsLayout
+  entries={events}
+  totalNumEvents={allEvents.length}
+  currentPage={pageNumber}
+/>

--- a/src/pages/[locale]/sketches/index.astro
+++ b/src/pages/[locale]/sketches/index.astro
@@ -7,20 +7,25 @@ import { sketchesPerPage } from "@/src/globals/globals";
 export async function getStaticPaths() {
   // First page on paginated route so we slice the first page
   const allSketches = await getCurationSketches();
-  const sketches = allSketches.slice(0, sketchesPerPage);
   const pages = nonDefaultSupportedLocales.map(async (locale) => ({
     params: {
       locale,
     },
     props: {
-      sketches,
+      allSketches,
     },
   }));
 
   return await Promise.all(pages);
 }
 
-const { sketches } = Astro.props;
+// First page on paginated route so we slice the first page
+const { allSketches } = Astro.props;
+const sketches = allSketches.slice(0, sketchesPerPage);
 ---
 
-<SketchesLayout entries={sketches} />
+<SketchesLayout
+  entries={sketches}
+  totalNumSketches={allSketches.length}
+  currentPage={1}
+/>

--- a/src/pages/[locale]/sketches/index.astro
+++ b/src/pages/[locale]/sketches/index.astro
@@ -2,9 +2,12 @@
 import SketchesLayout from "@/src/layouts/SketchesLayout.astro";
 import { nonDefaultSupportedLocales } from "@i18n/const";
 import { getCurationSketches } from "@/src/api/OpenProcessing";
+import { sketchesPerPage } from "@/src/globals/globals";
 
 export async function getStaticPaths() {
-  const sketches = await getCurationSketches();
+  // First page on paginated route so we slice the first page
+  const allSketches = await getCurationSketches();
+  const sketches = allSketches.slice(0, sketchesPerPage);
   const pages = nonDefaultSupportedLocales.map(async (locale) => ({
     params: {
       locale,

--- a/src/pages/[locale]/sketches/page/[...pageNumber].astro
+++ b/src/pages/[locale]/sketches/page/[...pageNumber].astro
@@ -1,0 +1,31 @@
+---
+import SketchesLayout from "@/src/layouts/SketchesLayout.astro";
+import { getCurationSketches } from "@src/api/OpenProcessing";
+import { getPaginationMax } from "@pages/_utils";
+import { sketchesPerPage } from "@/src/globals/globals";
+import { nonDefaultSupportedLocales } from "@/src/i18n/const";
+
+export async function getStaticPaths() {
+  const sketches = await getCurationSketches();
+  const paginationMax = getPaginationMax(sketchesPerPage, sketches.length);
+  const paths = [];
+  for (const locale of nonDefaultSupportedLocales) {
+    for (let i = 1; i <= paginationMax; i++) {
+      paths.push({
+        params: { locale, pageNumber: i.toString() },
+        props: {
+          sketches: sketches.slice(
+            (i - 1) * sketchesPerPage,
+            i * sketchesPerPage
+          ),
+        },
+      });
+    }
+  }
+  return paths;
+}
+
+const { sketches } = Astro.props;
+---
+
+<SketchesLayout entries={sketches} />

--- a/src/pages/[locale]/sketches/page/[...pageNumber].astro
+++ b/src/pages/[locale]/sketches/page/[...pageNumber].astro
@@ -14,18 +14,24 @@ export async function getStaticPaths() {
       paths.push({
         params: { locale, pageNumber: i.toString() },
         props: {
-          sketches: sketches.slice(
-            (i - 1) * sketchesPerPage,
-            i * sketchesPerPage
-          ),
+          allSketches: sketches,
+          pageNumber: i,
         },
       });
     }
   }
   return paths;
 }
-
-const { sketches } = Astro.props;
+const { allSketches, pageNumber } = Astro.props;
+let totalNumSketches = allSketches.length;
+const sketches = allSketches.slice(
+  (pageNumber - 1) * sketchesPerPage,
+  pageNumber * sketchesPerPage
+);
 ---
 
-<SketchesLayout entries={sketches} />
+<SketchesLayout
+  entries={sketches}
+  totalNumSketches={totalNumSketches}
+  currentPage={pageNumber}
+/>

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -209,3 +209,6 @@ export const escapeCodeTagsContent = (htmlString: string): string => {
   // Return the modified HTML as a string
   return $.html();
 };
+
+export const getPaginationMax = (numPerPage: number, numItems: number) =>
+  Math.ceil(numItems / numPerPage);

--- a/src/pages/past-events/index.astro
+++ b/src/pages/past-events/index.astro
@@ -1,8 +1,15 @@
 ---
 import EventsLayout from "@layouts/EventsLayout.astro";
 import { getCollectionInDefaultLocale } from "../_utils";
+import { eventsPerPage } from "@/src/globals/globals";
 
-const pastEvents = await getCollectionInDefaultLocale("past-events");
+// This route is a fallback for the first page on paginated route so we slice the first page
+const allPastEvents = await getCollectionInDefaultLocale("past-events");
+const pastEvents = allPastEvents.slice(0, eventsPerPage);
 ---
 
-<EventsLayout entries={pastEvents} />
+<EventsLayout
+  entries={pastEvents}
+  totalNumEvents={allPastEvents.length}
+  currentPage={1}
+/>

--- a/src/pages/past-events/page/[...pageNumber].astro
+++ b/src/pages/past-events/page/[...pageNumber].astro
@@ -1,0 +1,33 @@
+---
+import { eventsPerPage } from "@/src/globals/globals";
+import { getCollectionInDefaultLocale, getPaginationMax } from "../../_utils";
+import EventsLayout from "@/src/layouts/EventsLayout.astro";
+
+export async function getStaticPaths() {
+  const pastEvents = await getCollectionInDefaultLocale("past-events");
+  const paginationMax = getPaginationMax(eventsPerPage, pastEvents.length);
+  const paths = [];
+  for (let i = 1; i <= paginationMax; i++) {
+    paths.push({
+      params: { pageNumber: i.toString() },
+      props: {
+        allPastEvents: pastEvents,
+        pageNumber: i,
+      },
+    });
+  }
+  return paths;
+}
+
+const { allPastEvents, pageNumber } = Astro.props;
+const events = allPastEvents.slice(
+  (pageNumber - 1) * eventsPerPage,
+  pageNumber * eventsPerPage
+);
+---
+
+<EventsLayout
+  entries={events}
+  totalNumEvents={allPastEvents.length}
+  currentPage={pageNumber}
+/>

--- a/src/pages/sketches/index.astro
+++ b/src/pages/sketches/index.astro
@@ -1,8 +1,11 @@
 ---
+import { sketchesPerPage } from "@/src/globals/globals";
 import SketchesLayout from "@/src/layouts/SketchesLayout.astro";
 import { getCurationSketches } from "@src/api/OpenProcessing";
 
-const sketches = await getCurationSketches();
+// First page on paginated route so we slice the first page
+const allSketches = await getCurationSketches();
+const sketches = allSketches.slice(0, sketchesPerPage);
 ---
 
 <SketchesLayout entries={sketches} />

--- a/src/pages/sketches/index.astro
+++ b/src/pages/sketches/index.astro
@@ -8,4 +8,8 @@ const allSketches = await getCurationSketches();
 const sketches = allSketches.slice(0, sketchesPerPage);
 ---
 
-<SketchesLayout entries={sketches} />
+<SketchesLayout
+  entries={sketches}
+  totalNumSketches={allSketches.length}
+  currentPage={1}
+/>

--- a/src/pages/sketches/index.astro
+++ b/src/pages/sketches/index.astro
@@ -3,7 +3,7 @@ import { sketchesPerPage } from "@/src/globals/globals";
 import SketchesLayout from "@/src/layouts/SketchesLayout.astro";
 import { getCurationSketches } from "@src/api/OpenProcessing";
 
-// First page on paginated route so we slice the first page
+// This route is a fallback for the first page on paginated route so we slice the first page
 const allSketches = await getCurationSketches();
 const sketches = allSketches.slice(0, sketchesPerPage);
 ---

--- a/src/pages/sketches/page/[...pageNumber].astro
+++ b/src/pages/sketches/page/[...pageNumber].astro
@@ -1,0 +1,28 @@
+---
+import SketchesLayout from "@/src/layouts/SketchesLayout.astro";
+import { getCurationSketches } from "@src/api/OpenProcessing";
+import { getPaginationMax } from "../../_utils";
+import { sketchesPerPage } from "@/src/globals/globals";
+
+export async function getStaticPaths() {
+  const sketches = await getCurationSketches();
+  const paginationMax = getPaginationMax(sketchesPerPage, sketches.length);
+  const paths = [];
+  for (let i = 1; i <= paginationMax; i++) {
+    paths.push({
+      params: { pageNumber: i.toString() },
+      props: {
+        sketches: sketches.slice(
+          (i - 1) * sketchesPerPage,
+          i * sketchesPerPage
+        ),
+      },
+    });
+  }
+  return paths;
+}
+
+const { sketches } = Astro.props;
+---
+
+<SketchesLayout entries={sketches} />

--- a/src/pages/sketches/page/[...pageNumber].astro
+++ b/src/pages/sketches/page/[...pageNumber].astro
@@ -12,17 +12,24 @@ export async function getStaticPaths() {
     paths.push({
       params: { pageNumber: i.toString() },
       props: {
-        sketches: sketches.slice(
-          (i - 1) * sketchesPerPage,
-          i * sketchesPerPage
-        ),
+        allSketches: sketches,
+        pageNumber: i,
       },
     });
   }
   return paths;
 }
 
-const { sketches } = Astro.props;
+const { allSketches, pageNumber } = Astro.props;
+const totalSketches = allSketches.length;
+const sketches = allSketches.slice(
+  (pageNumber - 1) * sketchesPerPage,
+  pageNumber * sketchesPerPage
+);
 ---
 
-<SketchesLayout entries={sketches} />
+<SketchesLayout
+  entries={sketches}
+  totalNumSketches={totalSketches}
+  currentPage={pageNumber}
+/>


### PR DESCRIPTION
This PR adds pagination

Unfortunately I couldn't isolate this completely because a lot of information about the overall collection state is needed to paginate. Luckily pagination isn't used too much. This adds a pagination display and handles the slicing of data and route generation at the top of the 'past-events' and 'sketches' routes.

To view, go to the"Sketches Archive". Pagination is also working on the "Past Events Archive" but there are not enough events to create a second page currently