### PR TITLE
skip astro compress integration on test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
-      - name: Lint
+      - name: Test
         run: npm run test
   lint:
     runs-on: ubuntu-latest
@@ -43,5 +43,6 @@ jobs:
         run: npm ci
       - name: Build
         env:
+          SKIP_BUILD_COMPRESS: 1
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,16 @@ import mdx from "@astrojs/mdx";
 import compress from "astro-compress";
 import tailwind from "@astrojs/tailwind";
 
+// Allow skipping compression step for faster test build times
+// DO NOT SKIP COMPRESSION FOR DEPLOYMENT!
+const shouldSkipCompress = Boolean(
+  process.env.SKIP_BUILD_COMPRESS && process.env.SKIP_BUILD_COMPRESS.length > 0,
+);
+
+if (shouldSkipCompress) {
+  console.log("WILL SKIP COMPRESS BUILD STEP");
+}
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [
@@ -12,7 +22,7 @@ export default defineConfig({
     }),
     mdx(),
     tailwind(),
-    compress(),
+    shouldSkipCompress ? null : compress(),
   ],
   trailingSlash: "ignore",
   build: {


### PR DESCRIPTION
builds have climbed up to about 30m. skipping the compress integration for the test CI workflow should be safe and get automerged PRs in faster.