### PR TITLE
Prevent flash of light theme on navigate, monochrome wordmark/logomark

### DIFF
--- a/src/components/AccessibilitySettings/index.tsx
+++ b/src/components/AccessibilitySettings/index.tsx
@@ -33,7 +33,6 @@ export const AccessibilitySettings = ({
       }
     }
     setSelectedSettings(storedSettings);
-    document.body.classList.add(...storedSettings);
   }, []);
 
   const toggleSetting = (setting: PossibleA11ySettings) => {
@@ -42,7 +41,11 @@ export const AccessibilitySettings = ({
       : [...selectedSettings, setting];
     setSelectedSettings(newSettings);
     localStorage.setItem(setting, newSettings.includes(setting).toString());
-    document.body.classList.toggle(setting, newSettings.includes(setting));
+    applySetting(setting);
+  };
+
+  const applySetting = (setting: PossibleA11ySettings) => {
+    document.documentElement.classList.toggle(setting);
   };
 
   return (

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,12 +26,29 @@ const localizedTitle = t(title);
 const localizedSubtitle = t("briefPageDescriptions", title);
 ---
 
-<html>
+<html class={title.toLowerCase()}>
   <head>
+    <script is:inline>
+      // Get any theme settings and apply before load
+      const settings = [
+        "dark-theme",
+        "monochrome-theme",
+        "show-alt-text",
+        "reduced-motion",
+      ];
+      const storedSettings = settings.filter(
+        (setting) => localStorage.getItem(setting) === "true"
+      );
+      if (storedSettings.length === 0) {
+        storedSettings.push("light-theme");
+      }
+      const htmlElement = document.documentElement;
+      htmlElement.className = `${storedSettings.join(" ")} ${htmlElement.className}`;
+    </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
-  <body class={`${title.toLowerCase()} ${className}`}>
+  <body class={className}>
     <div class="top-layout-grid">
       <Nav />
       <Settings hideSearch={variant === "search"} />

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -132,4 +132,6 @@ html {
 
   --accent-color: var(--bg-white);
   --accent-type-color: var(--type-black);
+
+  --logo-color: var(--type-white);
 }

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -5,7 +5,7 @@ $breakpoint-tablet: 767px;
 $breakpoint-laptop: 1024px;
 $breakpoint-desktop: 1280px;
 
-:root {
+html {
   --font-sans: "National Park", sans-serif;
   --font-serif: "Courier", serif;
 
@@ -109,6 +109,8 @@ $breakpoint-desktop: 1280px;
 
   --accent-color: var(--bg-black);
   --accent-type-color: var(--type-white);
+
+  --logo-color: var(--type-black);
 }
 
 .dark-theme {


### PR DESCRIPTION
This PR prevents the flash of light theme on page navigate regardless of the applied theme. It does this by theming at the level of the `documentElement` instead and running a script before the body is mounted.

Unrelated to the primary aim of this PR but it also ensures that the logo variable updates for monochrome and dark mode.

fixes #207 

![no-flash-p5](https://github.com/bocoup/p5.js-website/assets/10382506/e12eab47-25af-40c4-ac93-f3bb728edc76)



