### PR TITLE
Stop spinning when limit motion setting on

### DIFF
--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -40,6 +40,9 @@ $breakpoint-desktop: 1280px;
   --accent-color: var(--bg-magenta-70);
   --accent-type-color: var(--type-black);
 
+  /* Animation */
+  --spin-degrees: 360deg;
+
   /* Spacing */
   --spacing-xxs: 0.25rem;
   --spacing-xs: 0.5rem;
@@ -130,4 +133,16 @@ $breakpoint-desktop: 1280px;
 
   --accent-color: var(--bg-white);
   --accent-type-color: var(--type-black);
+}
+
+.reduced-motion {
+  --spin-degrees: 0deg;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes spin {
+    to {
+      transform: rotate(var(--spin-degrees));
+    }
+  }
 }


### PR DESCRIPTION
This prevents spinning on the landing logo when the "reduce motion" is set even if the user's OS doesn't have the reduced motion setting on.