### PR TITLE
Add prefetch for links in viewport

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,6 +46,10 @@ export default defineConfig({
       },
     }),
   ],
+  prefetch: {
+    defaultStrategy: "viewport",
+    prefetchAll: true,
+  },
   trailingSlash: "ignore",
   build: {
     format: "directory",


### PR DESCRIPTION
The built-in Astro [prefetch is pretty sophisticated](https://docs.astro.build/en/guides/prefetch). I think that since it already accounts for the following it is a safe improvement to perceived performance.

> If a visitor is using [data saver mode](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/saveData) or has a [slow connection](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType), prefetch will fallback to the tap strategy.
Quickly hovering or scrolling over links will not prefetch them.
Links that use the viewport or load strategy are prefetched with a lower priority to avoid clogging up the network.