### PR TITLE
Fix code styles on Firefox Mobile

### DIFF
--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -7,7 +7,7 @@ $breakpoint-desktop: 1280px;
 
 html {
   --font-sans: "National Park", sans-serif;
-  --font-serif: "Courier", serif;
+  --font-serif: "Courier", monospace;
 
   /* Background Colors */
   --bg-yellow: #dfed33;


### PR DESCRIPTION
Quick fix for the code styles on Firefox Mobile because I figure no one else is using this browser so I might as well debug it myself 😅 

Turns out it just does not have Courier or Courier New for some reason? But the fallback font is just `serif` instead of a monospaced font, so I've changed it here. I guess the variable name `--font-serif` is a bit of a misnomer, but I haven't updated that, just its value.

Before: 
![Screenshot_20240424-144059.png](https://github.com/bocoup/p5.js-website/assets/5315059/c23b10ea-0a39-4268-b3d9-79d3edc4a85c)

After: 
![Screenshot_20240424-144046.png](https://github.com/bocoup/p5.js-website/assets/5315059/cfc7979f-54e3-4355-bd7a-96d70c2d7dee)

