### PR TITLE
Fix for localized categories in reference

### DIFF
--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -1,7 +1,6 @@
 import type { ReferenceDocContentItem } from "@/src/content/types";
 import { useMemo, useState } from "preact/hooks";
 import type { JSX } from "preact";
-import { getOneLineDescription } from "@/src/pages/_utils";
 
 type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   data: {
@@ -28,6 +27,21 @@ type ReferenceDirectoryWithFilterProps = {
       entries: ReferenceDirectoryEntry[];
     }[];
   }[];
+};
+
+/**
+ * Convert Reference description to one-line description
+ * @param description String description
+ * @returns One-line description
+ */
+const getOneLineDescription = (description: string): string => {
+  const stopCharacters = ["\\.|\\?|!|।|。"];
+  const fullStopRegex = new RegExp(`[${stopCharacters.join("")}]`, "g");
+  const cleanedDescription = description
+    .replace(/<[^>]*>?/gm, "")
+    .replace(/\n/g, " ");
+  const [oneLineDescription] = cleanedDescription.split(fullStopRegex, 1);
+  return `${oneLineDescription.trim()}.`;
 };
 
 export const ReferenceDirectoryWithFilter = ({

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -1,6 +1,7 @@
 import type { ReferenceDocContentItem } from "@/src/content/types";
 import { useMemo, useState } from "preact/hooks";
 import type { JSX } from "preact";
+import { getOneLineDescription } from "@/src/pages/_utils";
 
 type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   data: {
@@ -65,7 +66,7 @@ export const ReferenceDirectoryWithFilter = ({
           <a href={`/reference/${entry.data.path}`} class="text-body-mono">
             <span dangerouslySetInnerHTML={{ __html: entry.data.title }} />
           </a>
-          <p>{`${entry.data.description.replace(/<[^>]*>/g, "").split(/\.(\s|$)/, 1)[0]}.`}</p>
+          <p>{`${getOneLineDescription(entry.data.description)}`}</p>
         </div>
       ))}
     </div>

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -83,9 +83,70 @@ libraryCategories:
   export: "Export"
   utils: "Utilities"
 tutorialCategories:
-  introduction: 'Introduction to p5.js'
-  drawing: 'Drawing'
-  'web-design': 'Web Design'
-  accessibility: 'Accessibility'
-  webgl: 'WebGL'
-  'advanced': 'Advanced Topics'
+  introduction: "Introduction to p5.js"
+  drawing: "Drawing"
+  "web-design": "Web Design"
+  accessibility: "Accessibility"
+  webgl: "WebGL"
+  "advanced": "Advanced Topics"
+referenceCategories:
+  modules:
+    Foundation: Foundation
+    Image: Image
+    Typography: Typography
+    3D: 3D
+    Math: Math
+    Events: Events
+    Color: Color
+    Data: Data
+    Transform: Transform
+    Shape: Shape
+    Rendering: Rendering
+    DOM: DOM
+    Constants: Constants
+    p5.sound: p5.sound
+    IO: IO
+    Environment: Environment
+    Structure: Structure
+  submodules:
+    Foundation: Foundation
+    Pixels: Pixels
+    Loading & Displaying: Loading & Displaying
+    Material: Material
+    Calculation: Calculation
+    Acceleration: Acceleration
+    Trigonometry: Trigonometry
+    Creating & Reading: Creating & Reading
+    Lights: Lights
+    Array Functions: Array Functions
+    Transform: Transform
+    2D Primitives: 2D Primitives
+    Setting: Setting
+    Vertex: Vertex
+    3D Primitives: 3D Primitives
+    Curves: Curves
+    Rendering: Rendering
+    Conversion: Conversion
+    Camera: Camera
+    DOM: DOM
+    LocalStorage: LocalStorage
+    Constants: Constants
+    p5.sound: p5.sound
+    Image: Image
+    Dictionary: Dictionary
+    Vector: Vector
+    Output: Output
+    Environment: Environment
+    Time & Date: Time & Date
+    Interaction: Interaction
+    Structure: Structure
+    Mouse: Mouse
+    Attributes: Attributes
+    Input: Input
+    String Functions: String Functions
+    Keyboard: Keyboard
+    3D Models: 3D Models
+    Noise: Noise
+    Table: Table
+    Random: Random
+    Touch: Touch

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -48,3 +48,29 @@ briefPageDescriptions:
   Libraries: Expande las posibilidades de p5.js con bibliotecas creadas por la comunidad.
   About: Aprende acerca de la misión, valores y personas detrás de p5.js.
   People: Conoce al equipo de p5.js.
+referenceCategories:
+  modules:
+    Math: Matemáticas
+    Color: Color
+    Shape: Forma
+    DOM: DOM
+    Constants: Constantes
+    Image: Imagen
+    Environment: Ambiente
+    Typography: Tipografía
+  submodules:
+    Calculation: Cálculos
+    Trigonometry: Trigonometría
+    Creating & Reading: Creación y Lectura
+    2D Primitives: Primitivas 2D
+    Setting: Configuración
+    DOM: DOM
+    Constants: Constantes
+    Pixels: Píxeles
+    Image: Imagen
+    Vector: Vector
+    Environment: Ambiente
+    Attributes: Atributos
+    Loading & Displaying: Cargando y Mostrando
+    Noise: Ruido
+    Random: Aleatorio

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -48,3 +48,29 @@ briefPageDescriptions:
   Libraries: p5.js की संभावनाओं का विस्तार करें समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ।
   About: p5.js के पीछे मिशन, मूल्यों और लोगों के बारे में जानें।
   People: p5.js टीम को जानें।
+referenceCategories:
+  modules:
+    Typography: टाइपोग्राफी
+    Math: गणित
+    Color: रंग
+    Shape: आकार
+    DOM: डोम
+    Constants: स्थिरांक
+    Image: छवि
+    Environment: पर्यावरण
+  submodules:
+    Loading & Displaying: लोड होना और प्रदर्शित करना
+    Calculation: गणना
+    Trigonometry: त्रिकोणमिति
+    Creating & Reading: बनाना और पढ़ना
+    2D Primitives: 2D आदिम
+    Setting: स्थिरांक
+    DOM: डोम
+    Constants: स्थिरांक
+    Pixels: पिक्सल
+    Image: छवि
+    Vector: वेक्टर
+    Environment: पर्यावरण
+    Attributes: गुण
+    Noise: नॉइज़
+    Random: यादृच्छिक

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -48,3 +48,25 @@ briefPageDescriptions:
   Libraries: 커뮤니티가 만든 라이브러리로 p5.js의 가능성을 확장하세요.
   About: p5.js의 미션, 가치 및 주요 인물에 대해 알아보세요.
   People: p5.js 팀을 알아보세요.
+referenceCategories:
+  modules:
+    Math: 수학
+    Shape: 도형
+    DOM: 문서 객체 모델 (DOM)
+    Image: 이미지
+    Environment: 환경
+    Typography: 타이포그래피
+  submodules:
+    Calculation: 계산
+    Trigonometry: 삼각법
+    Creating & Reading: 만들기 & 읽기
+    2D Primitives: 2D 기초 조형
+    DOM: 문서 객체 모델 (DOM)
+    Pixels: 픽셀
+    Image: 이미지
+    Vector: 벡터
+    Environment: 환경
+    Attributes: 속성
+    Loading & Displaying: 불러오기 & 보이기
+    Noise: 노이즈
+    Random: 랜덤

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -48,3 +48,29 @@ briefPageDescriptions:
   Libraries: 使用社区创建的库扩展 p5.js 的可能性。
   About: 了解 p5.js 背后的使命、价值观和人员。
   People: 了解 p5.js 团队。
+referenceCategories:
+  modules:
+    Math: 数学
+    Color: 颜色
+    Shape: 形状
+    DOM: 文档对象模型
+    Constants: 常量
+    Image: 图像
+    Environment: 环境
+    Typography: 字体
+  submodules:
+    Calculation: 计算
+    Trigonometry: 三角函数
+    Creating & Reading: 创建 & 读取
+    2D Primitives: 2D 基础形状
+    Setting: 常量
+    DOM: 文档对象模型
+    Constants: 常量
+    Pixels: 像素
+    Image: 图像
+    Vector: 向量
+    Environment: 环境
+    Attributes: 属性
+    Loading & Displaying: 加载 & 显示
+    Noise: 噪声
+    Random: 随机

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -8,6 +8,7 @@ import {
   normalizeReferenceRoute,
 } from "../pages/_utils";
 import { setJumpToState } from "../globals/state";
+import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 
 type ReferenceEntry = CollectionEntry<"reference">;
 
@@ -26,10 +27,15 @@ function strCompare(a: string, b: string) {
   return 0;
 }
 
+const currentLocale = getCurrentLocale(Astro.url.pathname);
+const t = await getUiTranslator(currentLocale);
+
 const { entries } = Astro.props;
 const categoryData = categories.map((category) => {
   // Get all reference entries in the module
-  const directEntries = entries.filter((e) => e.data.module === category);
+  const directEntries = entries.filter(
+    (e) => e.data.module === t("referenceCategories", "modules", category)
+  );
 
   // Get the names of all submodules
   const subcats = [

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -7,7 +7,7 @@ import {
   getRefEntryTitleConcatWithParen,
   normalizeReferenceRoute,
 } from "../pages/_utils";
-import { setJumpToState } from "../globals/state";
+import { setJumpToState, type JumpToState } from "../globals/state";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 
 type ReferenceEntry = CollectionEntry<"reference">;
@@ -128,7 +128,8 @@ const pageJumpToLinks = categoryData.map((category) => ({
 
 const pageJumpToState = {
   links: pageJumpToLinks,
-};
+  heading: t("Reference") as string,
+} as JumpToState;
 
 setJumpToState(pageJumpToState);
 ---

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -116,7 +116,7 @@ const categoryData = categories.map((category) => {
     })),
   ];
   return {
-    name: category,
+    name: t("referenceCategories", "modules", category),
     subcats: subcatData,
   };
 });

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -412,3 +412,33 @@ const getUrl = (
       return "";
   }
 };
+
+/**
+ * Convert Reference description to one-line description
+ * @param description String description
+ * @returns One-line description
+ */
+export const getOneLineDescription = (description: string): string => {
+  const stopCharacters = getStopCharacters();
+  const fullStopRegex = new RegExp(`[${stopCharacters.join("")}]`, "g");
+  const cleanedDescription = description
+    .replace(/<[^>]*>?/gm, "")
+    .replace(/\n/g, " ");
+  const [oneLineDescription] = cleanedDescription.split(fullStopRegex, 1);
+  return `${oneLineDescription.trim()}.`;
+};
+
+export const getFullStopPunctuation = (locale: string): string => {
+  switch (locale) {
+    case "zh-Hans":
+      return "。";
+    case "hi":
+      return "।";
+    default:
+      return ".";
+  }
+};
+
+export const getStopCharacters = (): string[] => {
+  return ["\\.|\\?|!|।|。"];
+};

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -412,33 +412,3 @@ const getUrl = (
       return "";
   }
 };
-
-/**
- * Convert Reference description to one-line description
- * @param description String description
- * @returns One-line description
- */
-export const getOneLineDescription = (description: string): string => {
-  const stopCharacters = getStopCharacters();
-  const fullStopRegex = new RegExp(`[${stopCharacters.join("")}]`, "g");
-  const cleanedDescription = description
-    .replace(/<[^>]*>?/gm, "")
-    .replace(/\n/g, " ");
-  const [oneLineDescription] = cleanedDescription.split(fullStopRegex, 1);
-  return `${oneLineDescription.trim()}.`;
-};
-
-export const getFullStopPunctuation = (locale: string): string => {
-  switch (locale) {
-    case "zh-Hans":
-      return "。";
-    case "hi":
-      return "।";
-    default:
-      return ".";
-  }
-};
-
-export const getStopCharacters = (): string[] => {
-  return ["\\.|\\?|!|।|。"];
-};


### PR DESCRIPTION
Wrote a node script (not included since it was a one-time use) to extract the translated modules and submodules to fix #245

Now it looks like all of the translated reference links are included. I also handled the parsing of a single sentence using the fullstop characters for hindi and zh-Hans.

fixes #245 