### PR TITLE
fix createCapture preview clipping

### DIFF
--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -45,7 +45,7 @@ export const CodeEmbed = (props) => {
   }
 
   // Quick hack to make room for DOM that gets added below the canvas by default
-  const domMatch = /create(Button|Select|P|Div|Input|ColorPicker)/.exec(initialCode);
+  const domMatch = /create(Button|Select|P|Div|Input|ColorPicker|Capture)/.exec(initialCode);
   if (domMatch && previewHeight) {
     previewHeight += 100;
   }


### PR DESCRIPTION
Resolves #1204 

Adds `Capture` to the DOM check so `createCapture()` examples get extra preview height. Fixes the issue where the video was getting cut off below the canvas. Follows the same logic used for other DOM functions.