### PR TITLE
fix: adjust padding size on pages on 2.0 branch

### DIFF
--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -49,7 +49,7 @@ html {
   --spacing-xs: 0.5rem;
   --spacing-sm: 1rem;
   --spacing-md: 1.5rem;
-  --spacing-lg: 2rem;
+  --spacing-lg: 2.5rem;
   --spacing-xl: 3rem;
   --spacing-2xl: 4rem;
   --spacing-3xl: 5rem;


### PR DESCRIPTION
## Summary
- Readjusted the value of large space from 2rem to 2.5rem

## Why
- To adhere to the reference page

## Testing
- Chrome DevTools shows the left and right padding values is now 40px instead of 32px on the 2.0 branch

Partially Closes #1297