### PR TITLE
Fix SearchForm trailing slash

### DIFF
--- a/src/components/SearchForm/index.astro
+++ b/src/components/SearchForm/index.astro
@@ -7,7 +7,7 @@ const t = await getUiTranslator(currentLocale);
 ---
 
 <form
-  action={`${currentLocale === "en" ? "" : `/${currentLocale}`}/search`}
+  action={`${currentLocale === "en" ? "" : `/${currentLocale}`}/search/`}
   method="GET"
   role="search"
   class="relative w-full h-full text-accent-type-color bg-accent-color rounded-[20px] !mx-0"


### PR DESCRIPTION
resolves #1351 

- Fix the shared search form to use the canonical /search/ URL.
- This avoids local 404s and aligns the form behavior with the project’s trailing-slash conventions and search results page routing.