### PR TITLE
Fix: add localized fallback for p5.sound reference landing page

### DIFF
--- a/src/pages/[locale]/reference/p5.sound.astro
+++ b/src/pages/[locale]/reference/p5.sound.astro
@@ -1,0 +1,22 @@
+---
+import ReferenceLayout from "@layouts/ReferenceLayout.astro";
+import { nonDefaultSupportedLocales } from "@i18n/const";
+import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
+
+export async function getStaticPaths() {
+  const paths = nonDefaultSupportedLocales.map(async (locale) => {
+    const entries = await getCollectionInLocaleWithFallbacks("reference", locale);
+    const soundEntries = entries.filter((e) => e.data.module === "p5.sound");
+    return {
+      params: { locale },
+      props: { soundEntries },
+    };
+  });
+
+  return await Promise.all(paths);
+}
+
+const { soundEntries } = Astro.props;
+---
+
+<ReferenceLayout title="p5.sound Reference" entries={soundEntries} categories={["p5.sound"]} />


### PR DESCRIPTION
Resolves #1346 

## Changes:                                                                                                   
Adds a localized fallback route for the p5.sound reference landing page. Previously, /reference/p5.sound/ only existed for English. Visiting /es/reference/p5.sound/, /hi/reference/p5.sound/, /ko/reference/p5.sound/, or /zh-Hans/reference/p5.sound/ would result in a 404.

This PR adds src/pages/[locale]/reference/p5.sound.astro which generates the landing page for all non-default locales using getCollectionInLocaleWithFallbacks, falling back to English content where translations don't exist.

  ## PR Checklist:
- [x] `npm run lint` passes  
- [x] `npm run test` passes  
- [x] `npm run build` & `npm run preview` pass