### PR TITLE
Restore No Results translation string (used by search)

### DIFF
--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -43,6 +43,7 @@ Related Examples: Related Examples
 Show Code: Show Code
 Donate to p5.js: Donate to p5.js
 Download p5.js: Download p5.js
+No Results: No entries found for that search.
 No alt text: No alt text
 briefPageDescriptions:
   Reference: Find easy explanations for every piece of p5.js code.

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -44,6 +44,7 @@ Show Code: 코드 보기
 Donate to p5.js: p5.js에 기부하기
 Donate to Processing Foundation: Processing Foundation에 기부하기
 Download p5.js: p5.js 다운로드
+No Results: 검색 결과가 없습니다.
 No alt text: 대체 텍스트 없음
 briefPageDescriptions:
   Reference: p5.js 코드의 각 부분에 대한 쉬운 설명을 찾아보세요.

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -42,6 +42,7 @@ Show Code: 显示代码
 Donate to p5.js: 捐赠给 p5.js
 Donate to Processing Foundation: 捐赠给 Processing Foundation
 Download p5.js: 下载 p5.js
+No Results: 未找到相关条目
 No alt text: 无替代文本
 briefPageDescriptions:
   Reference: 找到每一段 p5.js 代码的简单解释。


### PR DESCRIPTION
Follows up on #1364.

Restores the No Results translation key in en, ko, and zh-Hans, it was accidentally removed as part of the filter removal, but it's also used by site-wide search, not just the filter.