### PR TITLE
Improve Korean typesetting

### DIFF
--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -107,3 +107,8 @@
     padding-bottom: 0;
   }
 }
+
+// Korean text needs more line spacing for readability
+html[lang="ko"] .rendered-markdown {
+  line-height: 1.7;
+}

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -108,7 +108,10 @@
   }
 }
 
-// Korean text needs more line spacing for readability
+
 html[lang="ko"] .rendered-markdown {
+  // Korean text needs more line spacing for readability
   line-height: 1.7;
+  // Prevent awkward Korean line breaks
+  word-break: keep-all;
 }


### PR DESCRIPTION
Addresses Issue #1376 

### Changes

#### Added Korean line spacing settings for improved readability

<img width="3200" height="1600" alt="image" src="https://github.com/user-attachments/assets/75c5e5d3-c750-41d9-8cc8-bf7b2006443f" />

#### Added `word-break: keep-all` to prevent awkward Korean line breaks

<img width="3200" height="1600" alt="image" src="https://github.com/user-attachments/assets/f2cbdeb4-cbc6-45df-9fb7-6d74f8657f73" />
<br/>

Latin text has natural break points at spaces, and browsers preserve alphabetic words by default. Korean text, under default East Asian line-breaking rules, may allow breaks between syllable blocks. `word-break: keep-all` tells the browser to avoid those intra-word CJK breaks and keep Korean word groups together, more like Latin words.