### PR TITLE
Add localized fallback route for p5.sound reference pages

### DIFF
--- a/src/pages/[locale]/reference/p5.sound.astro
+++ b/src/pages/[locale]/reference/p5.sound.astro
@@ -1,0 +1,22 @@
+---
+import ReferenceLayout from "@layouts/ReferenceLayout.astro";
+import { nonDefaultSupportedLocales } from "@i18n/const";
+import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
+
+export async function getStaticPaths() {
+  const paths = nonDefaultSupportedLocales.map(async (locale) => {
+    const entries = await getCollectionInLocaleWithFallbacks("reference", locale);
+    const soundEntries = entries.filter((e) => e.data.module === "p5.sound");
+    return {
+      params: { locale },
+      props: { soundEntries },
+    };
+  });
+
+  return await Promise.all(paths);
+}
+
+const { soundEntries } = Astro.props;
+---
+
+<ReferenceLayout title="p5.sound Reference" entries={soundEntries} categories={["p5.sound"]} />


### PR DESCRIPTION
Cherry-picked from #1362 to apply the same fix to the 2.0 branch.

The same 404 issue existed on the 2.0 branch for localized p5.sound reference pages. This PR applies mikhailbond1's fix to 2.0.