### PR TITLE
Improve Korean typesetting for 2.0 branch

### DIFF
--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -107,3 +107,11 @@
     padding-bottom: 0;
   }
 }
+
+
+html[lang="ko"] .rendered-markdown {
+  // Korean text needs more line spacing for readability
+  line-height: 1.7;
+  // Prevent awkward Korean line breaks
+  word-break: keep-all;
+}


### PR DESCRIPTION
Resolves #1376 

Applying changes made in #1392 to `2.0` branch.

~~While working on this, I noticed a difference between `main`, `2.0` branch markdown style file.~~

~~#1313 replaced `@import` with `@use`, but only on `2.0`. Should we apply this on `main` as well? Just wondering if it's ok to leave `main` as is, since we are moving to `2.0` eventually.~~

(edit) The issue(#1309) mentions applying the change on `main` as well.