### PR TITLE
[do not merge] Add privacy-first tracking

### DIFF
--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -63,6 +63,9 @@ export const CodeEmbed = (props) => {
       setPreviewCodeString(codeString);
     }
     announce("Sketch is running");
+
+    // Analytics for per-user (anonymized, no-cookie) conversion: did they run a sketch?
+    window.fathom.trackEvent(`Run Sketch`);
   };
 
   const [previewCodeString, setPreviewCodeString] = useState(codeString);

--- a/src/components/ReferenceTracker/index.tsx
+++ b/src/components/ReferenceTracker/index.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from "preact/hooks";
+
+const TIME_LABELS: Record<number, string> = {
+  10000: "Focus 10s",
+  30000: "Focus 30s",
+  90000: "Focus 90s",
+  300000: "Focus 5min",
+  600000: "Focus 10min",
+};
+
+const SCROLL_LABELS: Record<number, string> = {
+  25: "Scroll 25%",
+  50: "Scroll 50%",
+  75: "Scroll 75%",
+  100: "Scroll 100%",
+};
+
+const track = (label: string) => {
+  // Fathom analytics does not use cookies. The data collected
+  // is aggregate and minimal. The scope is currently only on
+  // the Reference page, but it can be generalized in the future.
+  if (window.fathom && window.location.pathname.startsWith("/reference/")) {
+    window.fathom.trackEvent(label);
+  }
+};
+
+const ReferenceTracker = ({
+  timeThresholds,
+  scrollThresholds,
+}: {
+  timeThresholds: number[];
+  scrollThresholds: number[];
+}) => {
+  const hasFiredTime = useRef<Set<number>>(new Set());
+  const hasFiredScroll = useRef<Set<number>>(new Set());
+  const elapsed = useRef(0);
+
+  useEffect(() => {
+    const tick = () => {
+      if (document.hidden) return;
+      elapsed.current += 1000;
+      for (const ms of timeThresholds) {
+        if (elapsed.current >= ms && !hasFiredTime.current.has(ms)) {
+          hasFiredTime.current.add(ms);
+          track(TIME_LABELS[ms]);
+        }
+      }
+    };
+
+    const onScroll = () => {
+      const max = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      if (max <= 0) return;
+      const pct = Math.round((window.scrollY / max) * 100);
+      for (const t of scrollThresholds) {
+        if (pct >= t && !hasFiredScroll.current.has(t)) {
+          hasFiredScroll.current.add(t);
+          track(SCROLL_LABELS[t]);
+        }
+      }
+    };
+
+    const interval = setInterval(tick, 1000);
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, [timeThresholds, scrollThresholds]);
+
+  return null;
+};
+
+export default ReferenceTracker;

--- a/src/components/SearchProvider/index.tsx
+++ b/src/components/SearchProvider/index.tsx
@@ -101,11 +101,20 @@ const SearchProvider = ({
         };
 
         const fuse = new Fuse(flatData, fuseOptions);
+        const fuseResults = fuse.search(searchTerm);
 
-        const searchResults = fuse
-          .search(searchTerm)
-          .map((result) => result.item);
+        const hasExactMatch = fuseResults.some(r => (r.score ?? 0) < 0.1);
+        if (fuseResults.length > 0 && window.fathom) {
+          if (hasExactMatch) {
+            // Only track search term if there is an exact match
+            window.fathom.trackEvent(`Search ${fuseResults.length} ${searchTerm}`);
+          } else {
+            // Otherwise, that a search occurred but without a match
+            window.fathom.trackEvent(`Search ${fuseResults.length} [FUZZY]`);
+          }
+        }
 
+        const searchResults = fuseResults.map((result) => result.item);
         setResults(searchResults);
       })
       .catch((error) =>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ import type { CollectionEntry } from "astro:content";
 import { render } from "astro:content";
 import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
 import { removeLocalePrefix } from "@i18n/utils";
+import ReferenceTracker from "@components/ReferenceTracker";
 
 interface Props {
   title: string;
@@ -132,5 +133,10 @@ const headerTopic = topic
       </main>
       <Footer />
     </div>
+    <ReferenceTracker 
+      client:load 
+      timeThresholds={[10000, 30000, 90000, 300000, 600000]} 
+      scrollThresholds={[25, 50, 75, 100]} 
+    />
   </body>
 </html>

--- a/types/fathom.d.ts
+++ b/types/fathom.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  fathom?: {
+    trackEvent(name: string, attrs?: Record<string, unknown>): void;
+  };
+}


### PR DESCRIPTION
Relates to / partially addresses https://github.com/processing/p5.js-website/issues/1242 and https://github.com/processing/p5.js-website/issues/1221 - part of working on this issue, Fathom Analytics has been setup. Fathom Analytics is a privacy-first tool that [does not use cookies](https://usefathom.com/docs/troubleshooting/cookies). It therefore has a few limitations relative to something like google analytics, but I believe it can address all or most of our actual needs. We do not currenlty use google analytics on the reference site (though it is used on the p5.js editor)

I am approaching these trackers like in a video game / game analytics. Running and editable code sketch block anywhere on the site is a conversion event on a per-user basis, so we can see % of unique users who did that.

Same for spending a certain amount of time focused on a page, or achieving a relative scroll depth. It is possible to use a secondary variable to see relative scroll depth or focus time conversion per user on each page:

<img width="515" height="119" alt="image" src="https://github.com/user-attachments/assets/0bb52e6b-9450-4fae-9f56-e49abf622d95" />

Finally, specific to the Search topic, terms are logged only when there are exact matches (string appear in the reference). Otherwise, they are redacted as "[FUZZY]", because that _might include personal information_. While unlikely, this follows the principle of **data minimization**: unless we have a good reason to collect the data, might as well not. Right now, there is no data. This would already be much better.

In all cases, the number of search results is included as a second component of the string, so the events can be exported and analyzed. 

<img width="214" height="391" alt="image" src="https://github.com/user-attachments/assets/5518dae5-e1a6-4316-b684-d59d7ccc89db" />

## Possible other changes

Maybe scroll % should only trigger after 30s? If someone scrolls up and down in the first 30s does that "count?" We should also see if we can notice such a pattern in the aggregate data.

Possibly search term count buckets should be applied, like with the others, such as:

* Search <10 [term]
* Search <50 [term]
* Search <100 [term]
* Search >100 [term]

Other Focus and Scroll buckets can be used, especially if informed by the previous studies about whats "enough" time. Scroll % would be useful on other parts of the site, too, but in my opinion it is better to roll these analytics out based on what actually corresponds to an active question.