### PR TITLE
Add p5.sound CDN link to download page

### DIFF
--- a/src/content/text-detail/en/download.mdx
+++ b/src/content/text-detail/en/download.mdx
@@ -22,8 +22,7 @@ This link redirects you to the p5.js Editor online so you can begin using p5.js 
 <LinkButton variant='link' url={`https://editor.p5js.org?version=${p5Version}`}> p5.js Editor </LinkButton>
 
 ### Download the Complete Library
-This is a download containing the p5.js library file and an example project. It does not contain an editor. It also does not contain p5.sound.js; please see below instructions for sound support.
-
+This is a download containing the p5.js library file and an example project. It does not contain an editor. If this download includes a p5.sound.js file, please disregard it — it is an outdated version incompatible with p5.js 2.x. See below for up-to-date sound support instructions.
 <LinkButton variant='download' url={fullDownloadUrl}> Complete Library </LinkButton>
 
 ### Download Single Files

--- a/src/content/text-detail/en/download.mdx
+++ b/src/content/text-detail/en/download.mdx
@@ -5,6 +5,7 @@ import LinkButton from '../../../components/LinkButton/index.astro'
 import CodeContainerWithCopy from "../../../components/CodeContainer/CodeContainerWithCopy.astro";
 import {
   cdnLibraryUrl,
+  cdnSoundUrl,
   fullDownloadUrl,
   libraryDownloadUrl,
   minifiedLibraryDownloadUrl,
@@ -21,7 +22,7 @@ This link redirects you to the p5.js Editor online so you can begin using p5.js 
 <LinkButton variant='link' url={`https://editor.p5js.org?version=${p5Version}`}> p5.js Editor </LinkButton>
 
 ### Download the Complete Library
-This is a download containing the p5.js library file, the p5.sound addon, and an example project. It does not contain an editor. Visit [Get Started](/tutorials/get-started) to learn how to setup a p5.js project.
+This is a download containing the p5.js library file and an example project. It does not contain an editor. Visit [Get Started](/tutorials/get-started) to learn how to setup a p5.js project.
 
 <LinkButton variant='download' url={fullDownloadUrl}> Complete Library </LinkButton>
 
@@ -32,6 +33,11 @@ These are downloads or links to the p5.js library file. No additional contents a
   <LinkButton variant='download' url={libraryDownloadUrl}> p5.js </LinkButton>
   <LinkButton variant='download' url={minifiedLibraryDownloadUrl}> p5.min.js </LinkButton>
 </div>
+
+### Sound Support with p5.sound
+p5.sound is maintained as a separate library from p5.js. If your sketch needs sound, add p5.sound to your project **in addition to** p5.js using the CDN link below, or visit [p5.sound on jsDelivr](https://www.jsdelivr.com/package/npm/p5.sound) for other versions and download options.
+
+<CodeContainerWithCopy>{cdnSoundUrl}</CodeContainerWithCopy>
 
 ## Use p5.js from CDN
 

--- a/src/content/text-detail/en/download.mdx
+++ b/src/content/text-detail/en/download.mdx
@@ -22,7 +22,7 @@ This link redirects you to the p5.js Editor online so you can begin using p5.js 
 <LinkButton variant='link' url={`https://editor.p5js.org?version=${p5Version}`}> p5.js Editor </LinkButton>
 
 ### Download the Complete Library
-This is a download containing the p5.js library file and an example project. It does not contain an editor. Visit [Get Started](/tutorials/get-started) to learn how to setup a p5.js project.
+This is a download containing the p5.js library file and an example project. It does not contain an editor. It also does not contain p5.sound.js; please see below instructions for sound support.
 
 <LinkButton variant='download' url={fullDownloadUrl}> Complete Library </LinkButton>
 
@@ -34,8 +34,8 @@ These are downloads or links to the p5.js library file. No additional contents a
   <LinkButton variant='download' url={minifiedLibraryDownloadUrl}> p5.min.js </LinkButton>
 </div>
 
-### Sound Support with p5.sound
-p5.sound is maintained as a separate library from p5.js. If your sketch needs sound, add p5.sound to your project **in addition to** p5.js using the CDN link below, or visit [p5.sound on jsDelivr](https://www.jsdelivr.com/package/npm/p5.sound) for other versions and download options.
+### Sound Support with p5.sound.js
+p5.sound.js is maintained as a separate library from p5.js. If your sketch needs sound, add p5.sound.js to your project **in addition to** p5.js using the CDN link below, or visit [p5.sound.js on jsDelivr](https://www.jsdelivr.com/package/npm/p5.sound) for other versions and download options.
 
 <CodeContainerWithCopy>{cdnSoundUrl}</CodeContainerWithCopy>
 


### PR DESCRIPTION
Part of processing/p5.js#9037

p5.sound is being removed from the p5.js complete library zip since it's
now maintained as a separate library. This adds a section to the download
page linking to the current p5.sound CDN build (using the existing but
previously-unused `cdnSoundUrl` global) and the jsDelivr package page.