### PR TITLE
fix: render promo banner as complementary landmark, not contentinfo

### DIFF
--- a/src/components/Banner/index.astro
+++ b/src/components/Banner/index.astro
@@ -3,15 +3,15 @@ import { render } from 'astro:content';
 import { Icon } from "@components/Icon"
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-const { link, title } = entry.data;
+const { link, title, label } = entry.data;
 ---
 
-<footer class="banner bg-accent-color text-accent-type-color" style={{ display: 'none' }} data-title={title} aria-label="sticky">
+<aside class="banner bg-accent-color text-accent-type-color" style={{ display: 'none' }} data-title={title} aria-label={label}>
   <a class="banner-content" href={link} target="_blank">
     <Content />
   </a>
   <button id="hideBanner" aria-label="Hide banner"><Icon kind="close" /></button>
-</footer>
+</aside>
 
 <script>
 const banner = document.querySelector('.banner');

--- a/src/content/banner/config.ts
+++ b/src/content/banner/config.ts
@@ -12,6 +12,8 @@ export const bannerCollection = defineCollection({
   schema: () =>
     z.object({
       title: z.string(),
+      // Accessible name for the banner landmark, announced by screen readers.
+      label: z.string(),
       link: z.string(),
       hidden: z.boolean().optional(),
     }),

--- a/src/content/banner/en.mdx
+++ b/src/content/banner/en.mdx
@@ -1,6 +1,7 @@
 ---
 # Give each new message a unique title so we know which one a user closed
 title: "v1-site"
+label: "p5.js v1 reference announcement"
 link: "https://v1.p5js.org"
 hidden: false
 ---


### PR DESCRIPTION
This PR addresses a duplicate `contentinfo` landmark issue introduced in https://github.com/processing/p5.js-website/pull/929.

Because both the promo banner and the main site footer were rendered as root-level `<footer>` elements, two `contentinfo` landmarks were generated in the accessibility tree. This was flagged during [Playwright axe-core scan](https://github.com/processing/p5.js-website/pull/1565) ([axe rule details](https://dequeuniversity.com/rules/axe/4.12/landmark-no-duplicate-contentinfo?application=playwright)). While HTML permits multiple footers, ARIA best practices recommend maintaining a single `contentinfo` landmark per document so screen reader users aren't confused with multiple primary footers (see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/contentinfo_role#one_contentinfo_landmark_per_page)).

Since the banner is a dismissible promo rather than main footer content, I think it should be reasonable to change the  landmark to `complementary` (using an HTML `<aside>`), which still keeps it easily accessible without conflicting with the main footer.

Visual styling remains unchanged. Feedback on the role or label choice is very welcome. Thanks!