### PR TITLE
Fix sidebar link text overflow with word-break

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -238,6 +238,7 @@
 
 .linklabel {
   text-decoration: none;
+  word-break: break-word;
 
   a:global(.current) {
     text-decoration-line: underline;


### PR DESCRIPTION
Fixes #1561

The "Jump To" sidebar links had no word-break/overflow-wrap constraint, so longer heading text at the larger font-size variant (used on Contribute doc pages) overflowed the sidebar and ran into the main content.

Added `word-break: break-word;` to `.linklabel` in `src/components/Nav/styles.module.scss`, as suggested by @ksen0 and confirmed by @doradocodes.

Tested locally on `/contribute/how-to-add-friendly-error-messages/` (the actual page from the bug report) at desktop width — sidebar text now wraps correctly instead of overflowing.

Note: this page's TOC is still fairly long/repetitive due to duplicate "Step 1/2/3/4" headings across sections (h3 depth). @ksen0 raised excluding these from the TOC as a possible follow-up — happy to open a separate PR for that if wanted, just didn't want to expand scope here without confirmation.