### PR TITLE
Fix framebuffer blur example for p5.js 2.x

### DIFF
--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -25,9 +25,10 @@ precision highp float;
 varying vec2 vTexCoord;
 uniform sampler2D img;
 uniform sampler2D depth;
-float getBlurriness(float d, float focalDepth) {
-  // Blur more the farther away we go from the focal point
-  return abs(d - focalDepth) * 200.;
+float getBlurriness(float d) {
+  // Blur more the farther away we go from the
+  // focal point at depth=0.9
+  return abs(d - 0.9) * 80.;
 }
 float maxBlurDistance(float blurriness) {
   // Cap the blur radius so far-away pixels don't smear
@@ -37,11 +38,8 @@ float maxBlurDistance(float blurriness) {
 void main() {
   vec4 color = texture2D(img, vTexCoord);
   float samples = 1.;
-  // Use the depth at the center of the canvas as the focal point,
-  // where the middle sphere sits, so it stays in focus
-  float focalDepth = texture2D(depth, vec2(0.5, 0.5)).r;
   float centerDepth = texture2D(depth, vTexCoord).r;
-  float blurriness = getBlurriness(centerDepth, focalDepth);
+  float blurriness = getBlurriness(centerDepth);
   for (int sample = 0; sample < 20; sample++) {
     // Sample nearby pixels in a spiral going out from the
     // current pixel
@@ -55,7 +53,7 @@ void main() {
 
     // How far should its blur reach?
     float sampleBlurDistance =
-      maxBlurDistance(getBlurriness(sampleDepth, focalDepth));
+      maxBlurDistance(getBlurriness(sampleDepth));
 
     // If it's in front of the current pixel, or its blur overlaps
     // with the current pixel, add its color to the average
@@ -75,7 +73,7 @@ let layer;
 let blur;
 
 function setup() {
-  createCanvas(windowWidth, windowHeight, WEBGL);
+  createCanvas(710, 400, WEBGL);
   angleMode(DEGREES);
   noStroke();
 
@@ -102,13 +100,11 @@ function draw() {
   // Rotate 1° per frame
   rotateY(frameCount);
 
-  // Place 5 spheres across canvas at equal distance
+  // Place 5 spheres across the canvas
   let sphereSize = min(width / 8, 35);
-  for (let i = 0; i < 5; i++) {
-    const x = map(i, 0, 4, -width / 2, width / 2);
-    const z = sin(map(i, 0, 4, -90, 90)) * 70;
+  for (let x = -width * 0.4; x <= width * 0.4; x += width * 0.2) {
     push();
-    translate(x, 0, z);
+    translate(x, 0, 0);
     sphere(sphereSize);
     pop();
   }

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -25,10 +25,9 @@ precision highp float;
 varying vec2 vTexCoord;
 uniform sampler2D img;
 uniform sampler2D depth;
-float getBlurriness(float d) {
-  // Blur more the farther away we go from the
-  // focal point at depth=0.82
-  return abs(d - 0.82) * 150.;
+float getBlurriness(float d, float focalDepth) {
+  // Blur more the farther away we go from the focal point
+  return abs(d - focalDepth) * 200.;
 }
 float maxBlurDistance(float blurriness) {
   // Cap the blur radius so far-away pixels don't smear
@@ -38,8 +37,11 @@ float maxBlurDistance(float blurriness) {
 void main() {
   vec4 color = texture2D(img, vTexCoord);
   float samples = 1.;
+  // Use the depth at the center of the canvas as the focal point,
+  // where the middle sphere sits, so it stays in focus
+  float focalDepth = texture2D(depth, vec2(0.5, 0.5)).r;
   float centerDepth = texture2D(depth, vTexCoord).r;
-  float blurriness = getBlurriness(centerDepth);
+  float blurriness = getBlurriness(centerDepth, focalDepth);
   for (int sample = 0; sample < 20; sample++) {
     // Sample nearby pixels in a spiral going out from the
     // current pixel
@@ -53,7 +55,7 @@ void main() {
 
     // How far should its blur reach?
     float sampleBlurDistance =
-      maxBlurDistance(getBlurriness(sampleDepth));
+      maxBlurDistance(getBlurriness(sampleDepth, focalDepth));
 
     // If it's in front of the current pixel, or its blur overlaps
     // with the current pixel, add its color to the average

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -98,9 +98,7 @@ function draw() {
   // Rotate 1° per frame
   rotateY(frameCount);
 
-  // Place 5 spheres across the canvas at equal distance,
-  // arcing slightly in depth so each one sits at a
-  // different distance from the camera
+  // Place 5 spheres across canvas at equal distance
   let sphereSize = min(width / 8, 35);
   for (let i = 0; i < 5; i++) {
     const x = map(i, 0, 4, -width / 2, width / 2);
@@ -119,9 +117,7 @@ function draw() {
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
 
-  // Render the scene captured by framebuffer with depth of field blur.
-  // push()/pop() scopes the shader so it doesn't carry into
-  // the next frame's drawing.
+  // Render the scene captured by framebuffer with depth of field blur
   push();
   shader(blur);
   plane(width, height);

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -27,8 +27,8 @@ uniform sampler2D img;
 uniform sampler2D depth;
 float getBlurriness(float d) {
   // Blur more the farther away we go from the
-  // focal point at depth=0.9
-  return abs(d - 0.9) * 40.;
+  // focal point at depth=0.82
+  return abs(d - 0.82) * 150.;
 }
 float maxBlurDistance(float blurriness) {
   return blurriness * 0.01;
@@ -98,12 +98,16 @@ function draw() {
   // Rotate 1° per frame
   rotateY(frameCount);
 
-  // Place 5 spheres across canvas at equal distance
-  let sphereDistance = width / 4;
-  for (let x = -width / 2; x <= width / 2; x += sphereDistance) {
+  // Place 5 spheres across the canvas at equal distance,
+  // arcing slightly in depth so each one sits at a
+  // different distance from the camera
+  let sphereSize = min(width / 8, 35);
+  for (let i = 0; i < 5; i++) {
+    const x = map(i, 0, 4, -width / 2, width / 2);
+    const z = sin(map(i, 0, 4, -90, 90)) * 70;
     push();
-    translate(x, 0, 0);
-    sphere();
+    translate(x, 0, z);
+    sphere(sphereSize);
     pop();
   }
 
@@ -115,7 +119,11 @@ function draw() {
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
 
-  // Render the scene captured by framebuffer with depth of field blur
+  // Render the scene captured by framebuffer with depth of field blur.
+  // push()/pop() scopes the shader so it doesn't carry into
+  // the next frame's drawing.
+  push();
   shader(blur);
   plane(width, height);
+  pop();
 }

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -31,7 +31,9 @@ float getBlurriness(float d) {
   return abs(d - 0.82) * 150.;
 }
 float maxBlurDistance(float blurriness) {
-  return blurriness * 0.01;
+  // Cap the blur radius so far-away pixels don't smear
+  // across the whole screen
+  return min(blurriness * 0.01, 0.05);
 }
 void main() {
   vec4 color = texture2D(img, vTexCoord);


### PR DESCRIPTION
## Summary

Fixes the 3D Framebuffer Blur example, which breaks on p5.js 2.x (see processing/p5.js#8940). The example was transferred here because the fix lives in the example itself, not the library.

## What changed

- **Scoped the blur shader.** Wrapped the final `shader(blur); plane(...)` pass in `push()`/`pop()` so `userFillShader` no longer leaks into the next frame's lit sphere pass (which caused the crescent smear / fading feedback loop in 2.x).
- **Smaller spheres.** Shrunk the spheres to `min(width/8, 35)` so the row reads clearly at the smaller sizes the website renders.
- **Arc in depth.** Spheres now sit at slightly different distances from the camera (z offset up to 70), so nearest/farthest spheres visibly fall out of focus, matching the example description.
- **Shallower depth of field.** Retuned the blur shader's focal point (`0.9` to `0.82`) and blur slope (`40` to `150`) so the DOF effect is visible given the compressed depth range of the default camera.

closes #1571