### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,16 +7,12 @@
 <!-- Summarize what this PR changes and why. -->
 
 ### Screenshots
-<!-- If this changes anything visual, add before/after screenshots. -->
-
-### Branch
-<!-- Which branch were these changes made against? -->
-
-- [ ] main
-- [ ] 2.0
+<!-- If this changes anything visual, add before/after screenshots (or a video for interaction changes). -->
 
 ### PR Checklist
 
 - [ ] `npm run lint` passes
 - [ ] `npm run test` passes
+- [ ] Tested changes with `npm run dev`
 - [ ] Tested on both desktop and mobile (for UI changes)
+- [ ] Added test(s) for this change, or explained why none are needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thank you for contributing to the p5.js website! Please fill out this template so reviewers have what they need to review your PR. -->
+
+### Resolves
+<!-- Add "resolves #XXXX" if this closes the issue, or "addresses #XXXX" if it's a partial fix. -->
+
+### Changes
+<!-- Summarize what this PR changes and why. -->
+
+### Screenshots
+<!-- If this changes anything visual, add before/after screenshots. -->
+
+### Branch
+<!-- Which branch were these changes made against? -->
+
+- [ ] main
+- [ ] 2.0
+
+### PR Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+- [ ] Tested on both desktop and mobile (for UI changes)


### PR DESCRIPTION
Resolves #988

Adds a `.github/PULL_REQUEST_TEMPLATE.md` for the website repo, based on the templates in `p5.js` and `p5.js-web-editor`, plus the branch/mobile-testing fields suggested in the issue discussion.