### PR TITLE
Add Fathom click tracking for reference filter vs global search usage

### DIFF
--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -186,6 +186,7 @@ export const ReferenceDirectoryWithFilter = ({
 }: ReferenceDirectoryWithFilterProps) => {
   const [searchKeyword, setSearchKeyword] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const hasTrackedFilterUse = useRef(false);
 
   const filteredEntries = useMemo(
     () => filterCategoryData(categoryData, searchKeyword),
@@ -307,7 +308,17 @@ export const ReferenceDirectoryWithFilter = ({
               placeholder={uiTranslations["Filter by keyword"]}
               onKeyUp={(e) => {
                 const target = e.target as HTMLInputElement;
-                setSearchKeyword(target?.value);
+                const value = target?.value ?? "";
+                setSearchKeyword(value);
+                if (
+                  !hasTrackedFilterUse.current &&
+                  value.trim().length > 0 &&
+                  typeof window !== "undefined" &&
+                  window.fathom
+                ) {
+                  hasTrackedFilterUse.current = true;
+                  window.fathom.trackEvent("Reference Filter Used");
+                }
               }}
             />
             {searchKeyword.length > 0 && (

--- a/src/components/SearchProvider/index.tsx
+++ b/src/components/SearchProvider/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import Fuse, { type FuseResult } from "fuse.js";
 import SearchResults from "../SearchResults";
 import { defaultLocale } from "@/src/i18n/const";
@@ -28,6 +28,7 @@ const SearchProvider = ({
 }: SearchProviderProps) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
+  const hasTrackedSearchUse = useRef(false);
 
   // Flattens the search index data
   
@@ -39,12 +40,22 @@ const SearchProvider = ({
     if (query) setSearchTerm(query);
   }, []);
 
-  // Update query param on search term update
+  // Update query param on search term update; track first non-empty use once
   useEffect(() => {
     if (searchTerm) {
       const params = new URLSearchParams(window.location.search);
       params.set("term", searchTerm);
       history.replaceState(null, "", `${window.location.pathname}?${params}`);
+
+      if (
+        !hasTrackedSearchUse.current &&
+        searchTerm.trim().length > 0 &&
+        typeof window !== "undefined" &&
+        window.fathom
+      ) {
+        hasTrackedSearchUse.current = true;
+        window.fathom.trackEvent("Global Search Used");
+      }
     }
   }, [searchTerm]);
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,11 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface FathomApi {
+  trackEvent: (eventName: string) => void;
+}
+
+interface Window {
+  fathom?: FathomApi;
+}


### PR DESCRIPTION
## Summary

Adds two Fathom custom click events so we can directly compare reference filter usage against sitewide search usage in the analytics dashboard, building on the base Fathom script added in #1511.

* `Reference Filter Used`: fires once per session on the first non-empty keystroke in the page-level "Filter by keyword" box on /reference/.
* `Global Search Used`: fires once per session on the first non-empty sitewide search term.

Both events are guarded behind `typeof window !== "undefined" && window.fathom`, so nothing breaks if the Fathom script hasn't loaded yet or is blocked.

## Why

Related to #1221 (Fathom analytics was one of the requested usability/design improvements). Right now filter and search usage aren't distinguishable in analytics, which makes it hard to tell how often each tool is actually used, something this round of usability research keeps running into.

## Testing

* 14/14 existing tests passing
* Full type check run, no other areas of the site affected
* Manually verified both events fire exactly once per session and don't fire on empty input

## Notes

I shared this branch with @ksen0 for a look before opening the PR (no changes requested), opening it now so it's in the queue for review.